### PR TITLE
Preserve hide_shadow when group operations recreate strands

### DIFF
--- a/src/group_layers.py
+++ b/src/group_layers.py
@@ -3035,6 +3035,8 @@ class GroupPanel(QWidget):
                 new_strand.is_hidden = original_strand.is_hidden
             if hasattr(original_strand, 'shadow_only'):
                 new_strand.shadow_only = original_strand.shadow_only
+            if hasattr(original_strand, 'hide_shadow'):
+                new_strand.hide_shadow = original_strand.hide_shadow
             if hasattr(original_strand, 'shadow_color'):
                 new_strand.shadow_color = QColor(original_strand.shadow_color)
             
@@ -3239,6 +3241,8 @@ class GroupPanel(QWidget):
                 new_strand.is_hidden = original.is_hidden
             if hasattr(original, 'shadow_only'):
                 new_strand.shadow_only = original.shadow_only
+            if hasattr(original, 'hide_shadow'):
+                new_strand.hide_shadow = original.hide_shadow
             if hasattr(original, 'start_line_visible'):
                 new_strand.start_line_visible = original.start_line_visible
             if hasattr(original, 'end_line_visible'):


### PR DESCRIPTION
## Summary
Audit follow-up for the Hide Shadow feature (#5): verified that undo/redo and save/load handle the `hide_shadow` flag correctly, and fixed the one gap found — `group_layers.py` copies `shadow_only` and other visual flags when group move/duplicate recreates strand objects, but `hide_shadow` was missing from both copy lists (masked-strand path and regular-strand path), so group edits silently reset a layer's hidden-shadow state.

## Verification (offscreen, real pipeline)
Undo/redo uses the same `save_strands`/`load_strands` JSON pipeline as file save/load (`undo_redo_manager.py` imports them directly), so one round-trip test covers both:
- [x] Regular strand with Hide Shadow ON → saved → loaded → still ON
- [x] Regular strand OFF stays OFF; masked strand ON stays ON (`1_1_2_1`)
- [x] Toggle OFF then save/load → all False (unhide persists, no stale state)
- [x] Legacy file without the `hide_shadow` key → defaults to False, no crash
- [x] Toggling registers as a visual difference in the undo manager (check added in the original PR), so each hide/unhide creates an undo step

🤖 Generated with [Claude Code](https://claude.com/claude-code)