### PR TITLE
Fix strand selection: hit-test the exact rendered geometry (select + mask mode)

### DIFF
--- a/automation_tests/test_selection_interaction.py
+++ b/automation_tests/test_selection_interaction.py
@@ -1,0 +1,404 @@
+"""
+Automation test: launches the real app (same as src/main.py) and drives the
+new exact-geometry selection with real mouse events, sweeping the strand
+option matrix:
+
+  - plain strand: body, stroke edge, side lines (shown AND hidden)
+  - attached strand (drawn with real attach-mode mouse drags): start junction
+    circle, end side line (shown AND hidden)
+  - end circle on the parent at the junction
+  - closed-connection start circle (shown, then transparent stroke -> gone)
+  - hidden layer -> not hoverable/selectable
+  - overlap: topmost strand wins hover and click
+  - mask mode: overlap click picks topmost (old code cancelled), two clicks
+    create the mask, then the mask itself is hoverable/selectable
+
+Run visibly (watch the app interact, cursor moves along):
+    python automation_tests\\test_selection_interaction.py --visible
+Run headless (CI):
+    python automation_tests\\test_selection_interaction.py
+
+Screenshots of every state are saved to automation_tests/screenshots/selection/.
+"""
+import os
+import sys
+import argparse
+import faulthandler
+
+ROOT_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+SRC_DIR = os.path.join(ROOT_DIR, "src")
+for p in (SRC_DIR, os.path.dirname(os.path.abspath(__file__))):
+    if p not in sys.path:
+        sys.path.insert(0, p)
+
+from test_menu_strand_flow import (_bootstrap_real_app, _draw_new_strand,
+                                   _attach_from_point, _strand_by_name,
+                                   _qt_imports)
+
+try:
+    import pytest
+    gui_mark = pytest.mark.gui
+except Exception:  # pragma: no cover
+    def gui_mark(func):
+        return func
+
+SHOT_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)),
+                        "screenshots", "selection")
+
+VISIBLE = False          # set from CLI; slows waits + moves the real cursor
+_PASS = 0
+_FAIL = 0
+
+
+def _wait(ms):
+    from PyQt5.QtTest import QTest
+    QTest.qWait(int(ms * (2.2 if VISIBLE else 1.0)))
+
+
+def _check(name, cond, detail=""):
+    global _PASS, _FAIL
+    if cond:
+        _PASS += 1
+        print("[PASS] %s" % name, flush=True)
+    else:
+        _FAIL += 1
+        print("[FAIL] %s  ::  %s" % (name, detail), flush=True)
+
+
+def _shot(canvas, name):
+    try:
+        os.makedirs(SHOT_DIR, exist_ok=True)
+        canvas.grab().save(os.path.join(SHOT_DIR, name + ".png"))
+    except Exception as exc:  # screenshots are best-effort
+        print("[automation] screenshot %s failed: %s" % (name, exc), flush=True)
+
+
+def _hover(canvas, x, y, pause=350):
+    """Send a real mouse-move to the canvas (hover), move the visible cursor
+    along with it, and let the canvas repaint."""
+    from PyQt5.QtCore import QPointF, QPoint, QEvent, Qt
+    from PyQt5.QtGui import QMouseEvent, QCursor
+    from PyQt5.QtWidgets import QApplication
+    if VISIBLE:
+        QCursor.setPos(canvas.mapToGlobal(QPoint(int(x), int(y))))
+    ev = QMouseEvent(QEvent.MouseMove, QPointF(x, y),
+                     Qt.NoButton, Qt.NoButton, Qt.NoModifier)
+    QApplication.sendEvent(canvas, ev)
+    canvas.repaint()
+    _wait(pause)
+
+
+def _click(canvas, x, y, pause=450):
+    from PyQt5.QtCore import QPoint, Qt
+    from PyQt5.QtGui import QCursor
+    from PyQt5.QtTest import QTest
+    if VISIBLE:
+        QCursor.setPos(canvas.mapToGlobal(QPoint(int(x), int(y))))
+    QTest.mouseClick(canvas, Qt.LeftButton, pos=QPoint(int(x), int(y)))
+    _wait(pause)
+
+
+def _screen(canvas, x, y):
+    """Canvas coords -> widget coords (handles any zoom/pan)."""
+    from PyQt5.QtCore import QPointF
+    p = canvas.canvas_to_screen(QPointF(x, y))
+    return p.x(), p.y()
+
+
+def _hovered(canvas):
+    return canvas.select_mode.hovered_strand
+
+
+def _hover_at_canvas(canvas, cx, cy, pause=350):
+    _hover(canvas, *_screen(canvas, cx, cy), pause=pause)
+    return _hovered(canvas)
+
+
+def _name(strand):
+    return getattr(strand, 'layer_name', None) if strand is not None else None
+
+
+def _run_automation(window, app):
+    from PyQt5.QtGui import QColor
+    from masked_strand import MaskedStrand
+
+    try:
+        canvas = window.canvas
+
+        # ============================================================ setup
+        print("[automation] drawing strand 1_1 (horizontal)...", flush=True)
+        _draw_new_strand(window, start_xy=(160, 220), end_xy=(460, 220), set_number=1)
+        s1 = _strand_by_name(canvas, "1_1")
+        _check("strand 1_1 drawn", s1 is not None)
+        if s1 is None:
+            return
+
+        y0 = s1.start.y()
+        half1 = (s1.width + 2 * s1.stroke_width) / 2
+        x_mid = (s1.start.x() + s1.end.x()) / 2
+
+        print("[automation] switching to select mode...", flush=True)
+        window.set_select_mode()
+        _wait(300)
+
+        # ============================================ 1) plain strand basics
+        got = _hover_at_canvas(canvas, x_mid, y0)
+        _check("plain: hover body highlights 1_1", got is s1, "hovered: %r" % _name(got))
+        _shot(canvas, "01_plain_body")
+
+        got = _hover_at_canvas(canvas, x_mid, y0 + half1 - 2)
+        _check("plain: hover stroke edge highlights 1_1", got is s1, "hovered: %r" % _name(got))
+        _shot(canvas, "02_plain_stroke_edge")
+
+        got = _hover_at_canvas(canvas, x_mid, y0 + half1 + 4)
+        _check("plain: just outside the stroke is empty", got is None, "hovered: %r" % _name(got))
+
+        # ------------------------------------------- side line shown/hidden
+        sideline_x = s1.start.x() - s1.stroke_width / 2
+        got = _hover_at_canvas(canvas, sideline_x, y0)
+        _check("side line shown: hover past the cap highlights 1_1",
+               got is s1, "hovered: %r" % _name(got))
+        _shot(canvas, "03_side_line_shown")
+
+        got = _hover_at_canvas(canvas, s1.start.x() - s1.stroke_width - 3, y0)
+        _check("side line shown: past the band is empty", got is None, "hovered: %r" % _name(got))
+
+        print("[automation] hiding 1_1 side lines...", flush=True)
+        s1.start_line_visible = False
+        s1.end_line_visible = False
+        canvas.update()
+        _wait(400)
+        got = _hover_at_canvas(canvas, sideline_x, y0)
+        _check("side line hidden: past the cap is empty", got is None, "hovered: %r" % _name(got))
+        got = _hover_at_canvas(canvas, x_mid, y0)
+        _check("side line hidden: body still hoverable", got is s1, "hovered: %r" % _name(got))
+        _shot(canvas, "04_side_line_hidden")
+        s1.start_line_visible = True
+        s1.end_line_visible = True
+        canvas.update()
+
+        # ========================================= 2) attached strand cases
+        print("[automation] attaching 1_2 at the end of 1_1 (real drag)...", flush=True)
+        jx, jy = s1.end.x(), s1.end.y()
+        _attach_from_point(window, attach_xy=(int(jx), int(jy)),
+                           end_xy=(int(jx), int(jy) + 180))
+        s12 = _strand_by_name(canvas, "1_2")
+        _check("attached strand 1_2 created", s12 is not None)
+
+        window.set_select_mode()
+        _wait(300)
+
+        if s12 is not None:
+            # junction circle: diagonally beyond both flat caps (15,15 -> ~21px
+            # from the junction, inside the 27px circle radius)
+            got = _hover_at_canvas(canvas, jx + 15, jy - 15)
+            _check("junction circle: hover beyond the flat caps highlights a strand",
+                   got in (s1, s12), "hovered: %r" % _name(got))
+            _shot(canvas, "05_junction_circle")
+
+            # attached strand's end side line
+            s12_end_y = s12.end.y()
+            got = _hover_at_canvas(canvas, s12.end.x(), s12_end_y + s12.stroke_width / 2)
+            _check("attached end side line: hover past the cap highlights 1_2",
+                   got is s12, "hovered: %r" % _name(got))
+            _shot(canvas, "06_attached_end_side_line")
+
+            print("[automation] hiding 1_2 end side line...", flush=True)
+            s12.end_line_visible = False
+            canvas.update()
+            _wait(400)
+            got = _hover_at_canvas(canvas, s12.end.x(), s12_end_y + s12.stroke_width / 2)
+            _check("attached end side line hidden: past the cap is empty",
+                   got is None, "hovered: %r" % _name(got))
+            _shot(canvas, "07_attached_side_line_hidden")
+            s12.end_line_visible = True
+            canvas.update()
+
+            # ---------------- fold / unfold start edge ----------------
+            # Folded (default): 1_2's start circle is stroked, radius 27.
+            # 25px behind the junction is inside it -> topmost 1_2 wins hover.
+            half12_in = s12.width / 2          # inner fill radius (23)
+            got = _hover_at_canvas(canvas, jx, jy - (half12_in + 2))
+            _check("folded start edge: hover 25px behind the junction highlights 1_2",
+                   got is s12, "hovered: %r" % _name(got))
+
+            # Unfold (same as the layer menu's 'Unfold Start Edge'): stroke
+            # becomes transparent but the inner fill circle is still drawn.
+            print("[automation] unfolding 1_2 start edge...", flush=True)
+            s12.start_circle_stroke_color = QColor(0, 0, 0, 0)
+            canvas.update()
+            _wait(400)
+            got = _hover_at_canvas(canvas, jx, jy - (half12_in - 3))
+            _check("unfolded start edge: fill circle (no stroke) still hovers as 1_2",
+                   got is s12, "hovered: %r" % _name(got))
+            _shot(canvas, "08a_unfolded_fill_circle")
+            got = _hover_at_canvas(canvas, jx, jy - (half12_in + 2))
+            _check("unfolded start edge: hidden stroke ring falls through to 1_1",
+                   got is s1, "hovered: %r" % _name(got))
+
+            # Fold back: the stroke ring is hoverable again.
+            print("[automation] folding 1_2 start edge back...", flush=True)
+            s12.start_circle_stroke_color = QColor(0, 0, 0, 255)
+            canvas.update()
+            _wait(400)
+            got = _hover_at_canvas(canvas, jx, jy - (half12_in + 2))
+            _check("refolded start edge: stroke ring hovers as 1_2 again",
+                   got is s12, "hovered: %r" % _name(got))
+            _shot(canvas, "08b_refolded_circle")
+
+            # hidden layer: not hoverable, hover falls through to nothing
+            print("[automation] hiding layer 1_2...", flush=True)
+            s12.is_hidden = True
+            canvas.update()
+            _wait(400)
+            mid12_y = (s12.start.y() + s12.end.y()) / 2
+            got = _hover_at_canvas(canvas, s12.start.x(), mid12_y)
+            _check("hidden layer: hover over hidden 1_2 is empty",
+                   got is None, "hovered: %r" % _name(got))
+            _shot(canvas, "08_hidden_layer")
+            s12.is_hidden = False
+            canvas.update()
+
+        # =========================== 3) circle options on an isolated strand
+        print("[automation] drawing strand 2_1 (vertical, crossing 1_1)...", flush=True)
+        x0 = int(x_mid)
+        _draw_new_strand(window, start_xy=(x0, 100), end_xy=(x0, 360), set_number=2)
+        s2 = _strand_by_name(canvas, "2_1")
+        _check("strand 2_1 drawn", s2 is not None)
+
+        window.set_select_mode()
+        _wait(300)
+
+        if s2 is not None:
+            x0 = s2.start.x()
+            top_y = min(s2.start.y(), s2.end.y())
+
+            # no circle, no junction: nothing renders past the cap except side line
+            got = _hover_at_canvas(canvas, x0, top_y - s2.stroke_width - 3)
+            _check("no circle: past the side line band is empty",
+                   got is None, "hovered: %r" % _name(got))
+
+            # closed-connection circle appears -> hoverable past the cap
+            print("[automation] enabling closed-connection start circle on 2_1...", flush=True)
+            s2.has_circles[0] = True
+            s2.closed_connections = [True, False]
+            canvas.update()
+            _wait(400)
+            got = _hover_at_canvas(canvas, x0, top_y - 20)
+            _check("closed-connection circle: hover 20px past the cap highlights 2_1",
+                   got is s2, "hovered: %r" % _name(got))
+            _shot(canvas, "09_closed_connection_circle")
+
+            # transparent circle stroke -> circle gone, nothing past the cap
+            print("[automation] making 2_1 start circle transparent...", flush=True)
+            s2.start_circle_stroke_color = QColor(0, 0, 0, 0)
+            canvas.update()
+            _wait(400)
+            got = _hover_at_canvas(canvas, x0, top_y - 20)
+            _check("transparent circle: hover past the cap is empty",
+                   got is None, "hovered: %r" % _name(got))
+            _shot(canvas, "10_transparent_circle")
+
+            # restore plain end
+            s2.start_circle_stroke_color = QColor(0, 0, 0, 255)
+            s2.has_circles[0] = False
+            s2.closed_connections = [False, False]
+            canvas.update()
+
+            # ============================== 4) overlap: topmost wins hover+click
+            got = _hover_at_canvas(canvas, x0, y0)
+            _check("overlap: hover on the crossing highlights topmost 2_1",
+                   got is s2, "hovered: %r" % _name(got))
+            _shot(canvas, "11_overlap_hover_topmost")
+
+            _click(canvas, *_screen(canvas, x0, y0))
+            _check("overlap: click on the crossing selects topmost 2_1",
+                   s2.is_selected and not s1.is_selected,
+                   "selected flags: 1_1=%s 2_1=%s" % (s1.is_selected, s2.is_selected))
+            _shot(canvas, "12_overlap_click_selected")
+
+            # ====================================================== 5) mask mode
+            print("[automation] switching to mask mode...", flush=True)
+            window.set_mask_mode()
+            _wait(300)
+
+            # overlap click: old code cancelled here; now picks topmost 2_1
+            _click(canvas, *_screen(canvas, x0, y0))
+            _check("mask mode: overlap click picks topmost strand (2_1)",
+                   canvas.mask_mode.selected_strands == [s2],
+                   "selected: %s" % [st.layer_name for st in canvas.mask_mode.selected_strands])
+            _shot(canvas, "13_mask_first_pick")
+
+            x_on_1_only = max(s1.start.x() + 20, x0 - 120)
+            _click(canvas, *_screen(canvas, x_on_1_only, y0))
+            _wait(800)
+            mask = next((st for st in canvas.strands if isinstance(st, MaskedStrand)), None)
+            _check("mask 2_1_1_1 created via two clicks",
+                   mask is not None and mask.layer_name == "2_1_1_1",
+                   "mask: %r" % _name(mask))
+            _shot(canvas, "14_mask_created")
+
+            # ================================ 6) the mask itself is selectable
+            if mask is not None:
+                window.set_select_mode()
+                _wait(300)
+
+                got = _hover_at_canvas(canvas, x0, y0)
+                _check("hover on mask center highlights the mask",
+                       got is mask, "hovered: %r" % _name(got))
+                _shot(canvas, "15_hover_mask")
+
+                _click(canvas, *_screen(canvas, x0, y0))
+                _check("click on mask center selects the mask",
+                       mask.is_selected, "mask.is_selected=%s" % mask.is_selected)
+                _shot(canvas, "16_click_mask_selected")
+
+        print("\n[automation] RESULT: %d passed, %d failed" % (_PASS, _FAIL), flush=True)
+
+    except Exception as exc:
+        print("[automation] FAILED with exception: %s" % exc, flush=True)
+        import traceback
+        traceback.print_exc()
+        globals()['_FAIL'] += 1
+
+    finally:
+        faulthandler.cancel_dump_traceback_later()
+        from PyQt5.QtCore import QTimer
+        # In visible mode leave the final state on screen for a moment
+        QTimer.singleShot(2500 if VISIBLE else 0, app.quit)
+
+
+@gui_mark
+def test_selection_interaction(visible=False):
+    """Launch the real app and drive selection with real mouse events."""
+    global VISIBLE
+    VISIBLE = visible
+    if not visible:
+        os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+    else:
+        os.environ.pop("QT_QPA_PLATFORM", None)
+
+    app, window = _bootstrap_real_app()
+
+    _, _, QTimer, _, _, *_ = _qt_imports()
+
+    window.show()
+    window.showMaximized()
+    window.raise_()
+    window.activateWindow()
+
+    if hasattr(window, 'set_initial_splitter_sizes'):
+        window.set_initial_splitter_sizes()
+
+    QTimer.singleShot(600, lambda: _run_automation(window, app))
+    app.exec_()
+    os._exit(1 if _FAIL else 0)
+
+
+if __name__ == "__main__":
+    faulthandler.enable(all_threads=True)
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--visible", action="store_true",
+                        help="Show the real app window while the test interacts")
+    args = parser.parse_args()
+    test_selection_interaction(visible=args.visible)

--- a/src/attached_strand.py
+++ b/src/attached_strand.py
@@ -170,41 +170,35 @@ class AttachedStrand(Strand):
         super(AttachedStrand, self.__class__).end.fset(self, value)
         self.update_shape()
 
-    def get_start_selection_path(self):
-        """Get the selection path for the starting point, excluding the inner area for control point selection."""
-        path = QPainterPath()
+    # Start/end selection paths are inherited from Strand and match the exact
+    # rendered geometry (width + stroke), so hit-testing follows the visible
+    # strand instead of an oversized invisible square around the start point.
 
-        # Base size for selection area - no zoom adjustment needed since we test in canvas coordinates
-        base_size = 120  # Base size of the selection square for the start edge
-        outer_size = base_size
+    def _end_circle_visible(self, side):
+        """Attached strands draw their start circle whenever the flag is set and
+        the stroke isn't transparent - no junction check like the base class."""
+        if side == 0:
+            return bool(self.has_circles and self.has_circles[0]
+                        and self.start_circle_stroke_color.alpha() > 0)
+        return super()._end_circle_visible(side)
 
-        half_outer_size = outer_size / 2
-        outer_rect = QRectF(
-            self.start.x() - half_outer_size,
-            self.start.y() - half_outer_size,
-            outer_size,
-            outer_size
-        )
+    def _end_side_line_visible(self, side):
+        """Attached strands never draw a start side line (the start is the
+        attachment point on the parent)."""
+        if side == 0:
+            return False
+        return super()._end_side_line_visible(side)
 
-        # Create the selection path by subtracting the inner rectangle from the outer rectangle
-        path.addRect(outer_rect)
-
-        return path
-
-    def get_end_selection_path(self):
-        """Get a selection path for the exact end point of the strand."""
-        # Create a small circle at the end point that matches the strand's end
-        end_path = QPainterPath()
-
-        # Base radius using strand width - no zoom adjustment needed since we test in canvas coordinates
-        base_radius = max(self.width / 2, 15)  # Minimum radius for clickability
-        radius = base_radius
-
-        end_path.addEllipse(self.end, radius, radius)
-        return end_path
- 
-
-
+    def get_end_decoration_path(self, side):
+        """Unfolded start edge: the circle stroke is transparent but draw()
+        still renders the inner fill circle (no stroke) so the start blends
+        into the parent - that fill circle is part of the footprint too."""
+        if (side == 0 and self.has_circles and self.has_circles[0]
+                and getattr(self, 'is_setting_staring_circle', False)
+                and self.start_circle_stroke_color.alpha() == 0):
+            angle = self._cap_tangent_angle(0)
+            return self._make_cap_inner(self.start, angle, self._partner_cap_dims(0)[1])
+        return super().get_end_decoration_path(side)
 
 
 

--- a/src/mask_mode.py
+++ b/src/mask_mode.py
@@ -3,6 +3,7 @@ from PyQt5.QtGui import QColor, QPainter, QPainterPathStroker, QPen, QPainterPat
 from PyQt5.QtWidgets import QApplication
 from masked_strand import MaskedStrand
 from render_utils import RenderUtils
+from selection_utils import find_strands_at_point
 
 class MaskMode(QObject):
     mask_created = pyqtSignal(object, object)  # Signal emitted when a mask is created
@@ -33,27 +34,19 @@ class MaskMode(QObject):
         pos = event.pos()
         strands_at_point = self.find_strands_at_point(pos)
 
-        if len(strands_at_point) == 1:
+        if strands_at_point:
+            # Topmost strand wins, exactly like select mode - overlapping
+            # strands no longer cancel the click.
             selected_strand, selection_type = strands_at_point[0]
             self.handle_strand_selection(selected_strand)
         else:
             self.clear_selection()
 
     def find_strands_at_point(self, pos):
-        results = []
-        for strand in self.canvas.strands:
-            # Skip masked strands entirely - we never want to select or hover them in mask mode
-            if isinstance(strand, MaskedStrand):
-                continue
-            contains_start = strand.get_start_selection_path().contains(pos)
-            contains_end = strand.get_end_selection_path().contains(pos)
-            if contains_start:
-                results.append((strand, 'start'))
-            elif contains_end:
-                results.append((strand, 'end'))
-            elif strand.get_selection_path().contains(pos):
-                results.append((strand, 'strand'))
-        return results
+        """Same hit-test as select mode (exact rendered geometry, topmost
+        strand first, hidden strands skipped), except masked strands are
+        excluded - they can't be components of a new mask."""
+        return find_strands_at_point(self.canvas.strands, pos, include_masked=False)
 
     def handle_strand_selection(self, strand):
         if strand not in self.selected_strands:
@@ -244,15 +237,9 @@ class MaskMode(QObject):
                 RenderUtils.setup_painter(painter, enable_high_quality=True)
 
                 strand = self.hovered_strand
-                # Get the path representing the strand
-                path = strand.get_path()
-
-                # Create a stroker for the highlight with squared ends
-                stroke_stroker = QPainterPathStroker()
-                stroke_stroker.setWidth(strand.width + strand.stroke_width * 2)
-                stroke_stroker.setJoinStyle(Qt.MiterJoin)
-                stroke_stroker.setCapStyle(Qt.FlatCap)  # Use FlatCap for squared ends
-                stroke_path = stroke_stroker.createStroke(path)
+                # Exact rendered footprint, same path used for hit-testing
+                # (body + end circles / side lines)
+                stroke_path = strand.get_selection_path()
 
                 # Draw the hover highlight with semi-transparent yellow (similar to selection rectangle style)
                 # Using QColor(255, 230, 160) like the control point selection boxes, but less transparent
@@ -277,15 +264,9 @@ class MaskMode(QObject):
             try:
                 RenderUtils.setup_painter(painter, enable_high_quality=True)
 
-                # Get the path representing the strand
-                path = strand.get_path()
-
-                # Create a stroker for the highlight with squared ends
-                stroke_stroker = QPainterPathStroker()
-                stroke_stroker.setWidth(strand.width + strand.stroke_width * 2)
-                stroke_stroker.setJoinStyle(Qt.MiterJoin)
-                stroke_stroker.setCapStyle(Qt.FlatCap)  # Use FlatCap for squared ends
-                stroke_path = stroke_stroker.createStroke(path)
+                # Exact rendered footprint, same path used for hit-testing
+                # (body + end circles / side lines)
+                stroke_path = strand.get_selection_path()
 
                 # Draw the highlight with transparent filling
                 highlight_color = QColor(self.canvas.highlight_color)

--- a/src/masked_strand.py
+++ b/src/masked_strand.py
@@ -277,6 +277,15 @@ class MaskedStrand(Strand):
                 mask_path = mask_path.subtracted(deletion_path)
         # Return fresh mask including deletions
         return mask_path
+
+    def get_selection_path(self):
+        """Get the exact rendered footprint of the mask for hit-testing.
+
+        The mask is drawn as the stroke-layer intersection (get_mask_path_stroke)
+        with the fill intersection (get_mask_path) on top, so the clickable area
+        is the union of both — including the visible stroke edge."""
+        return self.get_mask_path_stroke().united(self.get_mask_path())
+
     def _get_strand_start_circle_path(self, strand, radius):
         """Build the half-circle path at a strand's start point if the circle is visible.
         Returns an empty QPainterPath when the circle should not be included."""

--- a/src/select_mode.py
+++ b/src/select_mode.py
@@ -1,7 +1,7 @@
 from PyQt5.QtCore import QObject, pyqtSignal, QPointF, Qt
-from PyQt5.QtGui import QColor, QPainterPathStroker, QPen
+from PyQt5.QtGui import QColor, QPen
 from render_utils import RenderUtils
-from masked_strand import MaskedStrand
+from selection_utils import find_strands_at_point
 
 class SelectMode(QObject):
     strand_selected = pyqtSignal(int)
@@ -70,33 +70,10 @@ class SelectMode(QObject):
     def find_strands_at_point(self, pos):
         """Find strands at position - includes masked strands.
 
-        Checks strands in reverse order so topmost strands (drawn last) are found first.
-        Skips hidden strands.
+        Uses the shared hit-test (selection_utils) so the areas match the exact
+        rendered geometry, topmost strand first. Skips hidden strands.
         """
-        results = []
-        # Reverse order so topmost strands are checked first
-        for strand in reversed(self.canvas.strands):
-            # Skip hidden strands
-            if getattr(strand, 'is_hidden', False):
-                continue
-
-            # For MaskedStrand, check the actual mask path
-            if isinstance(strand, MaskedStrand):
-                # Use get_mask_path() which returns the actual visible mask shape
-                mask_path = strand.get_mask_path()
-                if mask_path.contains(pos):
-                    results.append((strand, 'strand'))
-            else:
-                # Regular strand detection
-                contains_start = strand.get_start_selection_path().contains(pos)
-                contains_end = strand.get_end_selection_path().contains(pos)
-                if contains_start:
-                    results.append((strand, 'start'))
-                elif contains_end:
-                    results.append((strand, 'end'))
-                elif strand.get_selection_path().contains(pos):
-                    results.append((strand, 'strand'))
-        return results
+        return find_strands_at_point(self.canvas.strands, pos, include_masked=True)
 
     def draw(self, painter):
         """Draw hover highlight for hovered strand."""
@@ -110,18 +87,10 @@ class SelectMode(QObject):
 
                 strand = self.hovered_strand
 
-                # For MaskedStrand, use the actual mask path
-                if isinstance(strand, MaskedStrand):
-                    # get_mask_path() returns the actual visible mask shape
-                    highlight_path = strand.get_mask_path()
-                else:
-                    # For regular strands, create a stroked path
-                    path = strand.get_path()
-                    stroke_stroker = QPainterPathStroker()
-                    stroke_stroker.setWidth(strand.width + strand.stroke_width * 2)
-                    stroke_stroker.setJoinStyle(Qt.MiterJoin)
-                    stroke_stroker.setCapStyle(Qt.FlatCap)
-                    highlight_path = stroke_stroker.createStroke(path)
+                # Exact rendered footprint, same path used for hit-testing:
+                # body + end circles / side lines for regular strands, and the
+                # stroke+fill mask footprint for masked strands.
+                highlight_path = strand.get_selection_path()
 
                 # Yellow hover highlight (same as mask mode)
                 hover_color = QColor(255, 230, 160, 170)

--- a/src/selection_utils.py
+++ b/src/selection_utils.py
@@ -1,0 +1,76 @@
+# src/selection_utils.py
+"""Shared strand hit-testing so every mode resolves clicks the same way.
+
+The hit areas match the exact rendered geometry of each strand:
+- regular/attached strand body: centerline stroked to width + 2 * stroke_width
+- endpoints: circles of the same visible radius (clipped to the body when no
+  circle is drawn at that end)
+- masked strand: the drawn mask (stroke layer united with fill layer)
+
+All widths are read from the strand at call time, so per-strand or per-set
+width/stroke changes are picked up automatically.
+"""
+
+from PyQt5.QtCore import QPointF
+
+from masked_strand import MaskedStrand
+
+# A click is a pixel, not an infinitesimal point. Sampling a few sub-pixel
+# offsets also works around a Qt quirk: QPainterPath.contains() (and even
+# intersects()) can return False exactly on internal seams of stroked
+# collinear curves — e.g. every point on the centerline of a perfectly
+# vertical strand.
+_HIT_TOLERANCE = 0.5
+_SAMPLE_OFFSETS = (
+    (0.0, 0.0),
+    (_HIT_TOLERANCE, 0.0), (-_HIT_TOLERANCE, 0.0),
+    (0.0, _HIT_TOLERANCE), (0.0, -_HIT_TOLERANCE),
+    (_HIT_TOLERANCE, _HIT_TOLERANCE), (-_HIT_TOLERANCE, _HIT_TOLERANCE),
+    (_HIT_TOLERANCE, -_HIT_TOLERANCE), (-_HIT_TOLERANCE, -_HIT_TOLERANCE),
+)
+
+
+def _path_hit(path, pos):
+    """Robust point-in-path test for hit-testing."""
+    if path.isEmpty():
+        return False
+    for dx, dy in _SAMPLE_OFFSETS:
+        if path.contains(QPointF(pos.x() + dx, pos.y() + dy)):
+            return True
+    return False
+
+
+def find_strands_at_point(strands, pos, include_masked=True):
+    """Hit-test strands at pos against their exact rendered geometry.
+
+    Iterates top-to-bottom (last drawn checked first), so the topmost strand
+    is first in the returned list. Hidden and deleted strands are skipped.
+
+    Args:
+        strands: iterable of strands in draw order (bottom to top).
+        pos (QPointF): position in canvas coordinates.
+        include_masked (bool): when False, MaskedStrand instances are skipped
+            entirely (mask mode can't use masks as mask components).
+
+    Returns:
+        list of (strand, selection_type) tuples, topmost strand first, where
+        selection_type is 'start', 'end' or 'strand'.
+    """
+    pos = QPointF(pos)
+    results = []
+    for strand in reversed(list(strands)):
+        if getattr(strand, 'is_hidden', False) or getattr(strand, 'deleted', False):
+            continue
+
+        if isinstance(strand, MaskedStrand):
+            if include_masked and _path_hit(strand.get_selection_path(), pos):
+                results.append((strand, 'strand'))
+            continue
+
+        if _path_hit(strand.get_start_selection_path(), pos):
+            results.append((strand, 'start'))
+        elif _path_hit(strand.get_end_selection_path(), pos):
+            results.append((strand, 'end'))
+        elif _path_hit(strand.get_selection_path(), pos):
+            results.append((strand, 'strand'))
+    return results

--- a/src/strand.py
+++ b/src/strand.py
@@ -581,31 +581,98 @@ class Strand:
             painter.restore()
 
 
+    def _end_circle_visible(self, side):
+        """Whether draw() renders an end-cap circle at the given end (0=start, 1=end).
+
+        Mirrors the draw() conditions: the flag must be set, the circle stroke
+        must not be fully transparent, and the end must actually be a junction
+        (an attached child starts there, or the connection is closed)."""
+        if not (self.has_circles and len(self.has_circles) > side and self.has_circles[side]):
+            return False
+        color = self.start_circle_stroke_color if side == 0 else self.end_circle_stroke_color
+        if color is not None and color.alpha() <= 0:
+            return False
+        from attached_strand import AttachedStrand
+        point = self.start if side == 0 else self.end
+        if any(isinstance(child, AttachedStrand) and child.start == point
+               and not getattr(child, 'shadow_only', False)
+               for child in getattr(self, 'attached_strands', [])):
+            return True
+        closed = getattr(self, 'closed_connections', None)
+        return bool(closed and len(closed) > side and closed[side])
+
+    def _end_side_line_visible(self, side):
+        """Whether draw() renders a side line at the given end (0=start, 1=end)."""
+        has_circle = bool(self.has_circles and len(self.has_circles) > side and self.has_circles[side])
+        if side == 0:
+            return bool(self.start_line_visible and not has_circle)
+        return bool(self.end_line_visible and not has_circle)
+
+    def _cap_tangent_angle(self, side):
+        """Tangent angle at an end, with the same fallbacks draw() uses."""
+        tangent = self.calculate_cubic_tangent(0.0001 if side == 0 else 0.9999)
+        if tangent.manhattanLength() == 0:
+            tangent = self.end - self.start
+        if tangent.manhattanLength() == 0:
+            return 0.0
+        return math.atan2(tangent.y(), tangent.x())
+
+    def get_end_decoration_path(self, side):
+        """Rendered decoration at an end: the cap circle when drawn, else the
+        side-line band, else an empty path.
+
+        The cap uses the same geometry as draw() (_make_cap_ellipse with the
+        partner dims, so elliptical end-caps match too); the forward half of the
+        full ellipse lies under the strand body, so the union stays exact. The
+        side line matches the drawn line: stroke_width thick, spanning the full
+        visible width just past the flat cap."""
+        if self._end_circle_visible(side):
+            point = self.start if side == 0 else self.end
+            angle = self._cap_tangent_angle(side)
+            return self._make_cap_ellipse(point, angle, side, self._partner_cap_dims(side)[0])
+        if self._end_side_line_visible(side):
+            a = getattr(self, 'start_line_start' if side == 0 else 'end_line_start', None)
+            b = getattr(self, 'start_line_end' if side == 0 else 'end_line_end', None)
+            if a is None or b is None:
+                return QPainterPath()
+            line = QPainterPath()
+            line.moveTo(a)
+            line.lineTo(b)
+            stroker = QPainterPathStroker()
+            stroker.setWidth(self.stroke_width)
+            stroker.setCapStyle(Qt.FlatCap)
+            return stroker.createStroke(line)
+        return QPainterPath()
+
     def get_start_selection_path(self):
-        """Get a selection path for the exact start point of the strand."""
-        # Create a small circle at the start point that matches the strand's start
+        """Get a selection path for the start point matching the rendered geometry.
+
+        The radius covers the full visible thickness (width plus stroke on both
+        sides), so it stays correct when the strand's width or stroke width is
+        changed. When no start circle is drawn, the zone is clipped to the
+        rendered footprint so it cannot extend past the visible cap."""
+        radius = (self.width + self.stroke_width * 2) / 2
         start_path = QPainterPath()
-
-        # Base radius using strand width - no zoom adjustment needed since we test in canvas coordinates
-        base_radius = max(self.width / 2, 15)  # Minimum radius for clickability
-        radius = base_radius
-
         start_path.addEllipse(self.start, radius, radius)
+        if not self._end_circle_visible(0):
+            start_path = start_path.intersected(self.get_selection_path())
         return start_path
     def draw_path(self, painter):
         """Draw the path of the strand without filling."""
         path = self.get_path()
         painter.drawPath(path)
     def get_end_selection_path(self):
-        """Get a selection path for the exact end point of the strand."""
-        # Create a small circle at the end point that matches the strand's end
+        """Get a selection path for the end point matching the rendered geometry.
+
+        The radius covers the full visible thickness (width plus stroke on both
+        sides), so it stays correct when the strand's width or stroke width is
+        changed. When no end circle is drawn, the zone is clipped to the strand
+        body so it cannot extend past the visible cap."""
+        radius = (self.width + self.stroke_width * 2) / 2
         end_path = QPainterPath()
-
-        # Base radius using strand width - no zoom adjustment needed since we test in canvas coordinates
-        base_radius = max(self.width / 2, 15)  # Minimum radius for clickability
-        radius = base_radius
-
         end_path.addEllipse(self.end, radius, radius)
+        if not self._end_circle_visible(1):
+            end_path = end_path.intersected(self.get_selection_path())
         return end_path
  
 
@@ -1628,12 +1695,22 @@ class Strand:
         return path
 
     def get_selection_path(self):
-        """Get the selection path for the entire strand body."""
-        # Use a wider path for easier selection - no zoom adjustment needed since we test in canvas coordinates
-        base_width = max(self.width, 20)  # Minimum width for clickability
-        selection_width = base_width
+        """Get the selection path for the entire rendered strand.
 
-        return self.get_stroked_path(selection_width)
+        Matches the exact drawn footprint: the body stroked to the full visible
+        thickness (fill plus stroke on both sides, FlatCap like draw()), united
+        with whatever is rendered at each end - the cap circle or the side line.
+        All widths are read live, so per-strand width/stroke changes apply."""
+        body_stroker = QPainterPathStroker()
+        body_stroker.setWidth(self.width + self.stroke_width * 2)
+        body_stroker.setJoinStyle(Qt.MiterJoin)
+        body_stroker.setCapStyle(Qt.FlatCap)
+        path = body_stroker.createStroke(self.get_path())
+        for side in (0, 1):
+            decoration = self.get_end_decoration_path(side)
+            if not decoration.isEmpty():
+                path = path.united(decoration)
+        return path
 
     def get_stroked_path(self, width: float) -> QPainterPath:
         """

--- a/tests/selection/test_selection_hit.py
+++ b/tests/selection/test_selection_hit.py
@@ -1,0 +1,505 @@
+"""Regression tests for exact-geometry strand selection (select mode).
+
+Run from anywhere:
+    python tests\\selection\\test_selection_hit.py
+
+Covers the three hit-testing fixes:
+  #1  an attached strand's start no longer claims clicks through an invisible
+      120x120 square - only its real rendered geometry counts
+  #2  the strand body hit area matches the drawn thickness
+      (width + 2*stroke_width), so clicks on the visible stroke edge land on
+      the top strand instead of falling through to the layer below
+  #3  a masked strand is clickable on its whole rendered footprint, including
+      the stroke edge (get_mask_path_stroke united with get_mask_path)
+Plus: topmost-first z-order, hidden strands skipped, and hit areas following
+per-strand width/stroke changes.
+"""
+
+import os
+import sys
+
+# This test lives in tests/selection/ ; the source modules are in <repo>/src.
+_SRC = os.path.normpath(
+    os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "..", "src"))
+sys.path.insert(0, _SRC)
+
+from PyQt5.QtCore import QPointF
+from PyQt5.QtGui import QColor
+
+from strand import Strand
+from attached_strand import AttachedStrand
+from masked_strand import MaskedStrand
+from select_mode import SelectMode
+from mask_mode import MaskMode
+
+# --------------------------------------------------------------------------- io
+_PASS = 0
+_FAIL = 0
+
+
+def check(name, cond, detail=""):
+    global _PASS, _FAIL
+    if cond:
+        _PASS += 1
+        print("[PASS] %s" % name)
+    else:
+        _FAIL += 1
+        print("[FAIL] %s  ::  %s" % (name, detail))
+
+
+# ---------------------------------------------------------------- test helpers
+class DummyCanvas:
+    """Minimal canvas stand-in for SelectMode hit-testing."""
+
+    def __init__(self):
+        self.strands = []
+        self.show_hover_highlights = True
+
+    def update(self):
+        pass
+
+    def setCursor(self, *_args):
+        pass
+
+
+def make_strand(start, end, set_number, layer_name, width=46, stroke_width=4):
+    s = Strand(
+        QPointF(*start), QPointF(*end), width,
+        color=QColor(200, 170, 230, 255),
+        stroke_color=QColor(0, 0, 0, 255),
+        stroke_width=stroke_width,
+        set_number=set_number, layer_name=layer_name,
+    )
+    s.update_control_points_from_geometry()
+    s.update_shape()
+    s.update_side_line()
+    return s
+
+
+def hits(strands, point):
+    """Topmost-first (strand, type) list at point via SelectMode."""
+    canvas = DummyCanvas()
+    canvas.strands = list(strands)
+    mode = SelectMode(canvas)
+    return mode.find_strands_at_point(QPointF(*point))
+
+
+def top_hit(strands, point):
+    result = hits(strands, point)
+    return result[0][0] if result else None
+
+
+def names(result):
+    return [s.layer_name for s, _t in result]
+
+
+# ------------------------------------------------------------------- case #2:
+# body hit area == drawn thickness (width + 2*stroke), any width/stroke
+def test_body_matches_rendered_thickness():
+    # width 46, stroke 4 -> visible half-thickness 27
+    a = make_strand((0, 0), (400, 0), 1, "1_1")
+
+    check("edge inside rendered stroke is a hit (y=26, half=27)",
+          top_hit([a], (200, 26)) is a,
+          "click on visible stroke edge missed the strand")
+    check("just outside rendered stroke is a miss (y=29)",
+          top_hit([a], (200, 29)) is None,
+          "hit area is larger than the rendered strand")
+
+    # narrow strand + wide stroke: width 10, stroke 10 -> half = 15
+    b = make_strand((0, 100), (400, 100), 1, "1_2", width=10, stroke_width=10)
+    check("narrow strand with wide stroke: y offset 14 is a hit",
+          top_hit([b], (200, 114)) is b,
+          "stroke width not included in hit area")
+    check("narrow strand with wide stroke: y offset 17 is a miss",
+          top_hit([b], (200, 117)) is None,
+          "hit area wider than rendered")
+
+    # width changed at runtime (width dialog): hit area must follow
+    a.width = 100  # half = (100 + 8) / 2 = 54
+    check("after width change, new edge is a hit (y=53)",
+          top_hit([a], (200, 53)) is a,
+          "hit area did not follow width change")
+    a.width = 46
+
+
+def test_top_strand_stroke_edge_wins_over_lower_body():
+    # a (bottom) covers y in [-27, 27]; b (top) at y=48 covers [21, 75].
+    a = make_strand((0, 0), (400, 0), 1, "1_1")
+    b = make_strand((0, 48), (400, 48), 2, "2_1")
+
+    # (200, 22): visually b's stroke edge drawn over a's body.
+    # Old code: b missed (26 > 23) and the click fell through to a.
+    check("click on top strand's stroke edge selects the top strand",
+          top_hit([a, b], (200, 22)) is b,
+          "click fell through to the strand below")
+    check("both strands reported, topmost first",
+          names(hits([a, b], (200, 22))) == ["2_1", "1_1"],
+          "z-order wrong: %s" % names(hits([a, b], (200, 22))))
+    # A point only on the bottom strand still selects it
+    check("point only on bottom strand selects it",
+          top_hit([a, b], (200, -20)) is a,
+          "bottom strand not selectable")
+
+
+# ------------------------------------------------------------------- case #1:
+# no invisible 120x120 square around an attached strand's start
+def test_attached_strand_has_no_invisible_square():
+    low = make_strand((0, 0), (400, 0), 1, "1_1")
+
+    parent = make_strand((200, 300), (200, 40), 2, "2_1")
+    attached = AttachedStrand(parent, QPointF(200, 40), 0)
+    attached.end = QPointF(200, 300)
+    parent.attached_strands.append(attached)
+
+    strands = [low, parent, attached]  # attached is topmost
+
+    # Click at (200, 0): on low's body; 40px from attached's start.
+    # Attached visible radius is 27, so nothing of attached is rendered there.
+    # Old code: attached's invisible 120x120 square claimed the click.
+    check("click on lower strand's body is not stolen by attached start square",
+          top_hit(strands, (200, 0)) is low,
+          "attached strand still claims clicks it doesn't render")
+
+    # Clicking on the attached strand's real start circle still works.
+    check("attached strand start circle (r=27) still selectable at 20px",
+          top_hit(strands, (200, 30)) is attached,
+          "attached start no longer selectable")
+
+    # 40px from start, past the visible circle, on nothing else -> no hit
+    # (points x-offset so it's off low's body and off attached's body).
+    check("40px away from attached start (empty pixel) is a miss",
+          top_hit([parent, attached], (160, 0)) is None,
+          "invisible zone still active around attached start")
+
+
+# ------------------------------------------------------------------- case #3:
+# masked strand clickable on full rendered footprint incl. stroke edge
+def test_mask_stroke_edge_is_clickable():
+    s1 = make_strand((0, 0), (400, 0), 1, "1_1")
+    s2 = make_strand((200, -200), (200, 200), 2, "2_1")
+    mask = MaskedStrand(s1, s2)
+    strands = [s1, s2, mask]
+
+    fill = mask.get_mask_path()
+    stroke = mask.get_mask_path_stroke()
+    check("mask paths are non-empty", not fill.isEmpty() and not stroke.isEmpty(),
+          "mask geometry did not build")
+
+    # Center of the intersection: mask is topmost -> mask wins.
+    check("center of mask selects the mask",
+          top_hit(strands, (200, 0)) is mask,
+          "mask not selected at its center")
+
+    # Find a rendered-stroke-only point (in stroke path, not in fill path).
+    edge_point = None
+    for dx in range(-30, 31):
+        for dy in range(-30, 31):
+            p = QPointF(200 + dx, 0 + dy)
+            if stroke.contains(p) and not fill.contains(p):
+                edge_point = p
+                break
+        if edge_point:
+            break
+    check("a stroke-only edge point exists", edge_point is not None,
+          "could not find stroke-edge point; mask geometry unexpected")
+
+    if edge_point:
+        # Old code hit-tested only the fill path, so this fell through.
+        check("click on mask's stroke edge selects the mask",
+              top_hit(strands, (edge_point.x(), edge_point.y())) is mask,
+              "mask stroke edge fell through to strand below")
+
+    # Away from the intersection the component strand is selected normally.
+    check("outside the mask, component strand is selected",
+          top_hit(strands, (100, 0)) is s1,
+          "component strand not selectable outside mask")
+
+
+# ----------------------------------------------------------------------- misc
+def test_hidden_strands_are_skipped():
+    a = make_strand((0, 0), (400, 0), 1, "1_1")
+    b = make_strand((0, 10), (400, 10), 2, "2_1")
+    b.is_hidden = True
+    check("hidden top strand is skipped",
+          top_hit([a, b], (200, 5)) is a,
+          "hidden strand still hit-tested")
+
+
+def test_select_mode_press_selects_topmost():
+    canvas = DummyCanvas()
+    a = make_strand((0, 0), (400, 0), 1, "1_1")
+    b = make_strand((0, 20), (400, 20), 2, "2_1")
+    canvas.strands = [a, b]
+    mode = SelectMode(canvas)
+
+    emitted = []
+    mode.strand_selected.connect(lambda idx: emitted.append(idx))
+
+    class FakeEvent:
+        def __init__(self, x, y):
+            self._p = QPointF(x, y)
+
+        def pos(self):
+            return self._p
+
+    # Overlap point: both strands contain (200, 10); topmost (b) must win.
+    mode.mousePressEvent(FakeEvent(200, 10))
+    check("press on overlap selects topmost strand",
+          b.is_selected and not a.is_selected,
+          "wrong strand selected on overlap")
+    check("selection signal carries topmost index",
+          emitted == [1], "emitted: %s" % emitted)
+
+    # Empty area deselects.
+    mode.mousePressEvent(FakeEvent(200, 400))
+    check("press on empty area deselects",
+          emitted[-1] == -1 and not b.is_selected,
+          "empty-area click did not deselect")
+
+
+# --------------------------------------------------- end decorations footprint
+# The rendered strand includes, per end, either a cap circle (when drawn) or a
+# side line band (stroke_width thick, just past the flat cap). The selection /
+# hover footprint must union exactly what is drawn - for every combination.
+
+def test_side_line_footprint_cases():
+    # Default strand (100,0)-(400,0): no circles, both side lines visible.
+    # Side line band: stroke 4 -> covers 4px just past each flat cap, spanning
+    # the full visible width (y in [-27, 27]).
+    s = make_strand((100, 0), (400, 0), 1, "1_1")
+
+    check("start side line: 2px past the cap is a hit",
+          top_hit([s], (98, 0)) is s, "side line not part of footprint")
+    check("start side line: full visible width is covered (y=26)",
+          top_hit([s], (98, 26)) is s, "side line band too narrow")
+    check("start side line: past the band is a miss (6px)",
+          top_hit([s], (94, 0)) is None, "footprint extends past the side line")
+    check("end side line: 2px past the cap is a hit",
+          top_hit([s], (402, 0)) is s, "end side line not part of footprint")
+    check("end side line: past the band is a miss",
+          top_hit([s], (406, 0)) is None, "footprint extends past the side line")
+
+    # Side lines hidden -> the footprint ends exactly at the flat cap.
+    s2 = make_strand((100, 0), (400, 0), 1, "1_2")
+    s2.start_line_visible = False
+    s2.end_line_visible = False
+    check("hidden start side line: past the cap is a miss",
+          top_hit([s2], (98, 0)) is None, "hidden side line still clickable")
+    check("hidden end side line: past the cap is a miss",
+          top_hit([s2], (402, 0)) is None, "hidden side line still clickable")
+    check("hidden side lines: body itself still selectable",
+          top_hit([s2], (250, 0)) is s2, "body lost")
+
+
+def test_end_circle_footprint_cases():
+    # End circle via an attached child at the end (junction circle).
+    parent = make_strand((100, 0), (400, 0), 1, "1_1")
+    child = AttachedStrand(parent, QPointF(400, 0), 1)
+    parent.attached_strands.append(child)
+    parent.has_circles[1] = True
+
+    # Circle radius = 27; a point 20px past the end is inside the drawn circle.
+    check("end circle (junction): 20px past the end is a hit",
+          parent.get_selection_path().contains(QPointF(420, 0)),
+          "junction end circle not part of footprint")
+    check("end circle (junction): 30px past the end is a miss",
+          not parent.get_selection_path().contains(QPointF(430, 0)),
+          "footprint larger than the drawn circle")
+
+    # Start circle via a closed connection.
+    s = make_strand((100, 0), (400, 0), 2, "2_1")
+    s.has_circles[0] = True
+    s.closed_connections = [True, False]
+    check("start circle (closed connection): 20px behind the start is a hit",
+          top_hit([s], (80, 0)) is s, "closed-connection circle not in footprint")
+
+    # has_circles set but the circle is NOT drawn (no junction, not closed):
+    # nothing is rendered past the cap (side line is suppressed by the flag).
+    s3 = make_strand((100, 0), (400, 0), 3, "3_1")
+    s3.has_circles[0] = True
+    check("has_circles without junction: nothing rendered past the cap",
+          top_hit([s3], (80, 0)) is None and top_hit([s3], (98, 0)) is None,
+          "undrawn circle or suppressed side line still clickable")
+
+    # Transparent circle stroke suppresses the drawn circle.
+    s4 = make_strand((100, 0), (400, 0), 4, "4_1")
+    s4.has_circles[0] = True
+    s4.closed_connections = [True, False]
+    s4.start_circle_stroke_color = QColor(0, 0, 0, 0)
+    check("transparent circle stroke: circle not part of footprint",
+          top_hit([s4], (80, 0)) is None, "transparent circle still clickable")
+
+
+def test_attached_strand_footprint_cases():
+    parent = make_strand((200, 300), (200, 40), 1, "1_1")
+    attached = AttachedStrand(parent, QPointF(200, 40), 0)
+    attached.end = QPointF(200, 300)
+    parent.attached_strands.append(attached)
+
+    # Attached strands always draw their start circle (default): 20px behind
+    # the start (radius 27) is inside it.
+    check("attached start circle: 20px behind the start is a hit",
+          attached.get_selection_path().contains(QPointF(200, 20)),
+          "attached start circle not part of footprint")
+
+    # End side line of the attached strand (no end circle): 2px past the end.
+    attached.update_side_line()
+    check("attached end side line: 2px past the end is a hit",
+          attached.get_selection_path().contains(QPointF(200, 302)),
+          "attached end side line not part of footprint")
+    attached.end_line_visible = False
+    check("attached hidden end side line: past the cap is a miss",
+          not attached.get_selection_path().contains(QPointF(200, 302)),
+          "hidden end side line still clickable")
+    attached.end_line_visible = True
+
+    # Folded start (stroke visible): full stroked circle, radius 27.
+    check("attached folded start circle: 25px behind the start is a hit (r=27)",
+          attached.get_selection_path().contains(QPointF(200, 15)),
+          "folded start circle ring not in footprint")
+
+    # Unfolded start edge (transparent stroke): draw() still renders the inner
+    # fill circle (radius width/2 = 23, no stroke) so the start blends into
+    # the parent - the fill circle must stay in the footprint, the stroke
+    # ring must not.
+    attached.start_circle_stroke_color = QColor(0, 0, 0, 0)
+    check("attached unfolded start: inner fill circle is a hit (20px, r=23)",
+          attached.get_selection_path().contains(QPointF(200, 20)),
+          "unfolded fill circle not united into footprint")
+    check("attached unfolded start: stroke ring is excluded (25px)",
+          not attached.get_selection_path().contains(QPointF(200, 15)),
+          "unfolded footprint still includes the hidden stroke ring")
+    attached.start_circle_stroke_color = QColor(0, 0, 0, 255)
+
+
+def test_hover_covers_decorations():
+    """Hover (select mode) must trigger on decorations, and the yellow
+    highlight uses the same footprint path, so they can never disagree."""
+    canvas = DummyCanvas()
+    s = make_strand((100, 0), (400, 0), 1, "1_1")
+    s.has_circles[1] = True
+    child = AttachedStrand(s, QPointF(400, 0), 1)
+    s.attached_strands.append(child)
+    canvas.strands = [s, child]
+    mode = SelectMode(canvas)
+
+    class FakeMove:
+        def __init__(self, x, y):
+            self._p = QPointF(x, y)
+
+        def pos(self):
+            return self._p
+
+    mode.mouseMoveEvent(FakeMove(98, 0))     # start side line band
+    check("hover on start side line highlights the strand",
+          mode.hovered_strand is s,
+          "hovered: %r" % (mode.hovered_strand and mode.hovered_strand.layer_name))
+
+    mode.mouseMoveEvent(FakeMove(420, 0))    # end junction circle
+    check("hover on end circle highlights a strand at that point",
+          mode.hovered_strand in (s, child),
+          "hovered: %r" % (mode.hovered_strand and mode.hovered_strand.layer_name))
+
+    mode.mouseMoveEvent(FakeMove(250, 200))  # empty area
+    check("hover on empty area clears the highlight",
+          mode.hovered_strand is None, "hover not cleared")
+
+
+# ------------------------------------------------------------------ mask mode
+class FakePress:
+    def __init__(self, x, y):
+        self._p = QPointF(x, y)
+
+    def pos(self):
+        return self._p
+
+
+def test_mask_mode_overlap_selects_topmost():
+    """Overlapping strands no longer cancel the click (old '== 1' rule)."""
+    canvas = DummyCanvas()
+    a = make_strand((0, 0), (400, 0), 1, "1_1")
+    b = make_strand((0, 20), (400, 20), 2, "2_1")
+    canvas.strands = [a, b]
+    mode = MaskMode(canvas, None)
+
+    # (200, 10) is inside both strands - old code cleared the selection here.
+    mode.handle_mouse_press(FakePress(200, 10))
+    check("mask mode: overlap click selects the topmost strand",
+          mode.selected_strands == [b],
+          "selected: %s" % [s.layer_name for s in mode.selected_strands])
+
+    # Second click on the other strand completes the pair (no crash without
+    # a connected mask_created handler).
+    mode.handle_mouse_press(FakePress(200, -20))
+    check("mask mode: second click adds the second strand",
+          mode.selected_strands == [b, a],
+          "selected: %s" % [s.layer_name for s in mode.selected_strands])
+
+    # Empty area clears.
+    mode.clear_selection()
+    mode.handle_mouse_press(FakePress(200, 400))
+    check("mask mode: empty-area click clears selection",
+          mode.selected_strands == [],
+          "selection not cleared")
+
+
+def test_mask_mode_matches_select_mode():
+    """Mask mode hit-testing must equal select mode minus masked strands."""
+    canvas = DummyCanvas()
+    s1 = make_strand((0, 0), (400, 0), 1, "1_1")
+    s2 = make_strand((200, -200), (200, 200), 2, "2_1")
+    mask = MaskedStrand(s1, s2)
+    hidden = make_strand((0, 5), (400, 5), 3, "3_1")
+    hidden.is_hidden = True
+    canvas.strands = [s1, s2, mask, hidden]
+
+    select = SelectMode(canvas)
+    mode = MaskMode(canvas, None)
+
+    for point in [(200, 0), (100, 0), (200, 100), (200, 22), (350, -10)]:
+        p = QPointF(*point)
+        from_select = [(s, t) for s, t in select.find_strands_at_point(p)
+                       if not isinstance(s, MaskedStrand)]
+        from_mask = mode.find_strands_at_point(p)
+        check("mask mode == select mode (minus masks) at %s" % (point,),
+              from_mask == from_select,
+              "select: %s mask: %s" % ([s.layer_name for s, _ in from_select],
+                                       [s.layer_name for s, _ in from_mask]))
+
+    # At the mask center, mask mode must pick the topmost component strand,
+    # never the masked strand itself.
+    mode.handle_mouse_press(FakePress(200, 0))
+    check("mask mode: click over a mask selects topmost component strand",
+          mode.selected_strands == [s2],
+          "selected: %s" % [s.layer_name for s in mode.selected_strands])
+
+    # Hidden strands are skipped (old mask mode did not filter them).
+    mode.clear_selection()
+    mode.handle_mouse_press(FakePress(300, 5))
+    check("mask mode: hidden strand is not selected",
+          mode.selected_strands == [s1],
+          "selected: %s" % [s.layer_name for s in mode.selected_strands])
+
+
+# ----------------------------------------------------------------------- main
+def main():
+    test_body_matches_rendered_thickness()
+    test_top_strand_stroke_edge_wins_over_lower_body()
+    test_attached_strand_has_no_invisible_square()
+    test_mask_stroke_edge_is_clickable()
+    test_hidden_strands_are_skipped()
+    test_select_mode_press_selects_topmost()
+    test_side_line_footprint_cases()
+    test_end_circle_footprint_cases()
+    test_attached_strand_footprint_cases()
+    test_hover_covers_decorations()
+    test_mask_mode_overlap_selects_topmost()
+    test_mask_mode_matches_select_mode()
+
+    print("\n%d passed, %d failed" % (_PASS, _FAIL))
+    return 1 if _FAIL else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Problem

Selection (select mode and mask mode) often didn't pick the strand under the cursor:

- The body hit area was `max(width, 20)` — clicking a strand's visible **stroke edge** fell through to the layer below (very noticeable with heavy stroke ratios from the width dialog).
- Attached strands had an invisible **120×120 square** around their start that stole clicks from strands actually under the cursor.
- Masked strands were hit-tested with the fill-only path, so the mask's **stroke edge** wasn't clickable.
- Mask mode required **exactly one** strand at the click point — clicking where strands overlap (the normal case when masking) silently cleared the selection instead of picking one. It also iterated bottom-up (hover highlighted the strand *behind*) and didn't skip hidden strands.

## Fix

One shared hit-test (`src/selection_utils.py`) used by both modes, resolving against the **exact rendered footprint, topmost strand first**:

- body stroked to `width + 2×stroke_width` (FlatCap, like `draw()`); widths read live so per-strand/per-set width & stroke changes apply immediately
- end decorations united exactly as drawn: junction cap circles (incl. elliptical partner-scaled caps), closed-connection circles, side-line bands, and the **unfolded start edge's** fill circle (transparent stroke); hidden side lines / transparent circles are excluded
- masked strands: hit area = drawn mask (stroke layer ∪ fill layer)
- mask mode picks the topmost strand on overlap (1st and 2nd component), skips hidden strands, hover matches click
- the yellow hover highlight in both modes draws the same footprint path as the hit-test, so what lights up is always exactly what a click selects
- robust point-in-path sampling works around `QPainterPath.contains()` returning `False` on the centerline seam of perfectly straight strands

## Tests

- `tests/selection/test_selection_hit.py` — 52 unit checks covering the full option matrix (width/stroke ratios, side lines shown/hidden, circles with/without junction, transparent, fold/unfold, hidden layers, z-order, mask parity)
- `automation_tests/test_selection_interaction.py` — 27 checks driving the **real app** with mouse events (draws strands, hovers, clicks, creates a mask); run with `--visible` to watch it interact, saves step screenshots
- existing suite `tests/1.108/test_tab_fixes.py` still 19/19

🤖 Generated with [Claude Code](https://claude.com/claude-code)