### PR TITLE
Add AGENTS.md with Cursor Cloud dev environment setup

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,41 @@
+# OpenStrand Studio
+
+A PyQt5 desktop GUI application for creating strand/knot diagrams. There is no
+backend, server, or database — persistence is local `.json` project files. The
+entry point is `python src/main.py`. See `README.md` and `PYTHON_FILES_OVERVIEW.md`
+for product/feature details.
+
+## Cursor Cloud specific instructions
+
+### Python environment
+- Dependencies live in a virtualenv at `$HOME/osenv` (the committed `.venv/` is a
+  Windows venv and does not work on Linux — ignore it). Run everything with
+  `"$HOME/osenv/bin/python"` (or `source "$HOME/osenv/bin/activate"`).
+- The update script installs `requirements.txt` and then force-installs
+  `PyQt5==5.15.11`. This override is required: the pinned `PyQt5==5.15.4` wheel is
+  ABI-incompatible with the newer `PyQt5-sip` on Python 3.12 and **segfaults at
+  import time** whenever a class uses multiple inheritance with a Qt base
+  (e.g. `class LayerPanel(StrandDataClipboardMixin, QWidget)` in
+  `src/layer_panel.py`). Do not downgrade PyQt5 back to 5.15.4 here.
+
+### Running the GUI (headless VM)
+- This is a GUI app, so it needs a display. A TigerVNC server runs on `DISPLAY=:1`
+  (visible in the Desktop pane) — launch the app there for interactive/manual
+  testing: `DISPLAY=:1 "$HOME/osenv/bin/python" src/main.py`.
+- For non-interactive/import checks you can use `QT_QPA_PLATFORM=offscreen`.
+- Gotcha: creating a strand in the UI is a two-step action — click **New Strand**,
+  then click on the canvas to place it. A `1_1` layer button then appears.
+
+### Tests
+- Two styles coexist under `tests/`:
+  - True pytest files (e.g. `tests/copy_paste/`): `QT_QPA_PLATFORM=offscreen "$HOME/osenv/bin/python" -m pytest tests/copy_paste/ -q`
+  - Script-style tests that call `sys.exit()` at import (most others). Do **not**
+    run these through `pytest` (collection crashes on their `SystemExit`); run them
+    directly, e.g. `QT_QPA_PLATFORM=offscreen "$HOME/osenv/bin/python" tests/selection/test_selection_hit.py`.
+
+### Notes / gotchas
+- The root `Procfile` (`web: gunicorn app:app`) is vestigial — there is no `app.py`
+  and no web service. Ignore it.
+- The optional `json_to_png_exporter/` tool renders offscreen widget grabs; on this
+  headless Linux setup some exports come out blank even though the on-screen GUI
+  renders correctly. It is not part of the core product.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up and documents the development environment for OpenStrand Studio (a PyQt5 desktop app) so it can be built, tested, and run in the Cursor Cloud VM.

Adds `AGENTS.md` capturing durable, non-obvious setup/run guidance for future agents.

## Environment setup performed

- Created a Linux virtualenv at `$HOME/osenv` (the committed `.venv/` is a Windows venv, unusable on Linux).
- Installed `requirements.txt` (PyQt5, pillow) + `pytest`.
- Installed system Qt/xcb libraries + `xvfb` for headless GUI rendering.

## Key finding: PyQt5 5.15.4 segfault on Python 3.12

The pinned `PyQt5==5.15.4` wheel is ABI-incompatible with the newer `PyQt5-sip` on Python 3.12 and **segfaults at import time** on multiple-inheritance Qt classes (e.g. `class LayerPanel(StrandDataClipboardMixin, QWidget)`). The update script force-installs `PyQt5==5.15.11` to fix this. `requirements.txt` is left unchanged so production/Windows builds are unaffected; the override lives only in the update script.

## Verification

- App launches and renders the full GUI (toolbar, grid canvas, layer panel).
- Hello-world: created a strand via the GUI (New Strand → click canvas → `1_1` layer appears).
- Tests pass: 12 pytest (`tests/copy_paste/`) + script-style suites (`test_selection_hit.py` 63, `test_cp_visibility_during_drag.py` 9, etc.).

[openstrand_create_strand_demo.mp4](https://cursor.com/agents/bc-186b1f0e-5137-45b6-8b0c-92e2d68d2025/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fopenstrand_create_strand_demo.mp4)

[Strand created on canvas](https://cursor.com/agents/bc-186b1f0e-5137-45b6-8b0c-92e2d68d2025/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fopenstrand_strand_created.png)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-186b1f0e-5137-45b6-8b0c-92e2d68d2025"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-186b1f0e-5137-45b6-8b0c-92e2d68d2025"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

