### PR TITLE
Record what produced every undo/redo state

### DIFF
--- a/src/SAVE_LOAD_UNDO_REDO_GUIDE.md
+++ b/src/SAVE_LOAD_UNDO_REDO_GUIDE.md
@@ -69,11 +69,27 @@ def toggle_my_property(self, strand, layer_panel):
         if layer_panel and hasattr(layer_panel, 'canvas'):
             layer_panel.canvas.update()
 
-            # Save state for undo/redo
+            # Save state for undo/redo, recording WHAT produced this state
+            # (see "Recording WHAT Produced a State" below).
             if hasattr(layer_panel.canvas, 'undo_redo_manager'):
                 # Force save by resetting the last save time
                 layer_panel.canvas.undo_redo_manager._last_save_time = 0
-                layer_panel.canvas.undo_redo_manager.save_state()
+                layer_panel.canvas.undo_redo_manager.save_state(
+                    action='strand.my_new_property',   # add it to ACTIONS first
+                    source='menu',
+                    targets=[getattr(strand, 'layer_name', None)],
+                    detail='on' if strand.my_new_property else 'off',
+                )
+```
+
+Add the id to `ACTIONS` in `undo_redo_metadata.py` at the same time, so the
+history reads "Toggled my new property" rather than the prettified id:
+
+```python
+ACTIONS = {
+    # ...
+    "strand.my_new_property": "Toggled my new property",
+}
 ```
 
 ## Example: Full Arrow Implementation

--- a/src/SAVE_LOAD_UNDO_REDO_GUIDE.md
+++ b/src/SAVE_LOAD_UNDO_REDO_GUIDE.md
@@ -94,6 +94,42 @@ The `full_arrow_visible` property is a complete example of this pattern:
 ### 4. Toggle with Undo/Redo
 - `numbered_layer_button.py` line 2270-2282: `toggle_strand_full_arrow_visibility` function
 
+## Recording WHAT Produced a State
+
+Every saved state also carries a record of the action behind it — the mode that
+was active, or the panel, dialog or menu entry responsible — so the undo stack
+doubles as a log of what was done. `undo_redo_metadata.py` owns that record;
+`save_state` takes it:
+
+```python
+undo_redo_manager.save_state(
+    action='strand.hidden',      # an id from undo_redo_metadata.ACTIONS
+    source='menu',               # mode / panel / dialog / menu / shortcut / system
+    targets=[strand.layer_name], # what it touched (names, strands, or indices via layer_names)
+    detail='hidden',             # anything extra worth reading back
+)
+```
+
+Nothing is mandatory: a `save_state()` with no arguments still records the
+active mode and the calling function, so no state is completely anonymous. Add
+a new id to `ACTIONS` when you add a new kind of edit — an uncatalogued id still
+renders readably, it just reads as its own name.
+
+The record is written **inside the state file** (`undo_metadata`), so it
+survives a restart, `export_history`/`import_history` and session recovery.
+Older state files simply have none and read back as unrecorded.
+
+What it feeds:
+
+- The undo/redo button tooltips, which name the action they would reverse or replay.
+- The **Recorded actions** list on the Settings → History page: this session's
+  activity (edits, undos and redos), or a past session's saved steps.
+- A readable log next to the state files (`<session id>_history.log`).
+- `undo_redo_manager.get_history_entries()` / `get_session_journal()` for anything else.
+
+When adding a new property toggle (the walkthrough above), pass an `action` in
+step 4 — that is the only extra line the history needs.
+
 ## Key Implementation Details
 
 ### Save/Load Manager

--- a/src/angle_adjust_mode.py
+++ b/src/angle_adjust_mode.py
@@ -577,7 +577,9 @@ class AngleAdjustMode:
 
             # Save state for undo/redo after angle adjustment (skip_save flag already cleared in dialog cleanup)
             if hasattr(self.canvas, 'layer_panel') and hasattr(self.canvas.layer_panel, 'undo_redo_manager'):
-                self.canvas.layer_panel.undo_redo_manager.save_state()
+                self.canvas.layer_panel.undo_redo_manager.save_state(
+                    action='angle.adjust', source='mode',
+                    targets=[getattr(self.active_strand, 'layer_name', None)])
 
             # Deactivate the angle adjust mode
             self.canvas.is_angle_adjusting = False

--- a/src/group_layers.py
+++ b/src/group_layers.py
@@ -2271,7 +2271,8 @@ class GroupPanel(QWidget):
                 try:
                     if hasattr(self.canvas, 'layer_panel') and self.canvas.layer_panel is not None and hasattr(self.canvas.layer_panel, 'undo_redo_manager'):
                         self._rotation_save_done = True
-                        self.canvas.layer_panel.undo_redo_manager.save_state()
+                        self.canvas.layer_panel.undo_redo_manager.save_state(
+                            action='group.rotate', source='dialog', targets=[group_name])
                 except RuntimeError:
                     pass
 
@@ -3514,7 +3515,9 @@ class GroupPanel(QWidget):
             # Save undo/redo state before opening
             if hasattr(self.canvas, 'undo_redo_manager') and self.canvas.undo_redo_manager:
                 self.canvas.undo_redo_manager._last_save_time = 0
-                self.canvas.undo_redo_manager.save_state()
+                self.canvas.undo_redo_manager.save_state(
+                    action='group.shadow', source='dialog', targets=[group_name],
+                    detail='before opening the shadow editor')
 
             from group_shadow_editor_dialog import GroupShadowEditorDialog
             # Store reference to prevent garbage collection of non-modal dialog
@@ -6791,11 +6794,13 @@ class StrandAngleEditDialog(QDialog):
             # Only save state on the layer panel's undo/redo manager to prevent duplicate saves
             if self.canvas and hasattr(self.canvas, 'layer_panel') and hasattr(self.canvas.layer_panel, 'undo_redo_manager'):
                 self.canvas.layer_panel.undo_redo_manager._skip_save = False
-                self.canvas.layer_panel.undo_redo_manager.save_state()
+                self.canvas.layer_panel.undo_redo_manager.save_state(
+                    action='group.angle', source='dialog', targets=[self.group_name])
             elif self.canvas and hasattr(self.canvas, 'undo_redo_manager'):
                 # Fallback to canvas undo/redo manager if layer panel doesn't have one
                 self.canvas.undo_redo_manager._skip_save = False
-                self.canvas.undo_redo_manager.save_state()
+                self.canvas.undo_redo_manager.save_state(
+                    action='group.angle', source='dialog', targets=[self.group_name])
     def start_continuous_adjustment_plus(self):
         self.stop_adjustment()
         self.current_adjustment = self.delta_continuous_plus

--- a/src/group_shadow_editor_dialog.py
+++ b/src/group_shadow_editor_dialog.py
@@ -682,6 +682,7 @@ class GroupShadowEditorDialog(QDialog):
 
         if hasattr(self.canvas, 'undo_redo_manager') and self.canvas.undo_redo_manager:
             self.canvas.undo_redo_manager._last_save_time = 0
-            self.canvas.undo_redo_manager.save_state()
+            self.canvas.undo_redo_manager.save_state(
+                action='group.shadow', source='dialog', targets=[self.group_name])
 
         super().closeEvent(event)

--- a/src/layer_panel.py
+++ b/src/layer_panel.py
@@ -10,7 +10,7 @@ from PyQt5.QtGui import QDragEnterEvent, QDragMoveEvent, QDropEvent, QPainter, Q
 from render_utils import RenderUtils
 # --- End Import ---
 # Names the undo/redo provenance record uses to say WHICH layers an action touched.
-from undo_redo_metadata import layer_names
+from undo_redo_metadata import layer_names, set_member_names
 from functools import partial
 from masked_strand import MaskedStrand
 from attached_strand import AttachedStrand
@@ -3330,8 +3330,10 @@ class LayerPanel(StrandDataClipboardMixin, QWidget):
             if not getattr(self.undo_redo_manager, '_suppress_intermediate_saves', False):
                 # Reset last save time to force save, as color change alone might not be detected otherwise
                 self.undo_redo_manager._last_save_time = 0 
-                self.undo_redo_manager.save_state(action='strand.color', source='dialog',
-                                                  detail='set {}'.format(set_number))
+                self.undo_redo_manager.save_state(
+                    action='strand.color', source='dialog',
+                    targets=set_member_names(self.canvas, set_number),
+                    detail='set {}'.format(set_number))
             else:
                 pass
             # --- END ADD --- 

--- a/src/layer_panel.py
+++ b/src/layer_panel.py
@@ -9,6 +9,8 @@ from PyQt5.QtGui import QColor, QPalette, QDrag, QGuiApplication, QCursor, QIcon
 from PyQt5.QtGui import QDragEnterEvent, QDragMoveEvent, QDropEvent, QPainter, QPen # Added Painter/Pen
 from render_utils import RenderUtils
 # --- End Import ---
+# Names the undo/redo provenance record uses to say WHICH layers an action touched.
+from undo_redo_metadata import layer_names
 from functools import partial
 from masked_strand import MaskedStrand
 from attached_strand import AttachedStrand
@@ -1559,7 +1561,10 @@ class LayerPanel(StrandDataClipboardMixin, QWidget):
             if hasattr(self.canvas, 'undo_redo_manager') and self.canvas.undo_redo_manager:
                 # Force save by resetting timing check to ensure visibility changes are captured
                 self.canvas.undo_redo_manager._last_save_time = 0
-                self.canvas.undo_redo_manager.save_state()
+                self.canvas.undo_redo_manager.save_state(
+                    action='strand.hidden', source='panel',
+                    targets=[getattr(strand, 'layer_name', None)],
+                    detail='hidden' if strand.is_hidden else 'shown')
 
         else:
             pass
@@ -1589,7 +1594,10 @@ class LayerPanel(StrandDataClipboardMixin, QWidget):
             if hasattr(self.canvas, 'undo_redo_manager') and self.canvas.undo_redo_manager:
                 # Force save by resetting timing check to ensure shadow-only changes are captured
                 self.canvas.undo_redo_manager._last_save_time = 0
-                self.canvas.undo_redo_manager.save_state()
+                self.canvas.undo_redo_manager.save_state(
+                    action='strand.shadow_only', source='panel',
+                    targets=[getattr(strand, 'layer_name', None)],
+                    detail='on' if getattr(strand, 'shadow_only', False) else 'off')
             else:
                 pass
 
@@ -1617,7 +1625,10 @@ class LayerPanel(StrandDataClipboardMixin, QWidget):
             if hasattr(self.canvas, 'undo_redo_manager') and self.canvas.undo_redo_manager:
                 # Force save by resetting timing check to ensure hide-shadow changes are captured
                 self.canvas.undo_redo_manager._last_save_time = 0
-                self.canvas.undo_redo_manager.save_state()
+                self.canvas.undo_redo_manager.save_state(
+                    action='strand.hide_shadow', source='panel',
+                    targets=[getattr(strand, 'layer_name', None)],
+                    detail='on' if getattr(strand, 'hide_shadow', False) else 'off')
             else:
                 pass
 
@@ -2081,7 +2092,9 @@ class LayerPanel(StrandDataClipboardMixin, QWidget):
         if hasattr(self.canvas, 'undo_redo_manager') and self.canvas.undo_redo_manager:
             # Force save by resetting last save time to ensure this is captured as a new state
             self.canvas.undo_redo_manager._last_save_time = 0
-            self.canvas.undo_redo_manager.save_state()
+            self.canvas.undo_redo_manager.save_state(
+                action='strand.hidden', source='panel', detail='hide',
+                targets=layer_names(self.canvas, self.multi_selected_layers))
         else:
             pass
         
@@ -2110,7 +2123,9 @@ class LayerPanel(StrandDataClipboardMixin, QWidget):
         if hasattr(self.canvas, 'undo_redo_manager') and self.canvas.undo_redo_manager:
             # Force save by resetting last save time to ensure this is captured as a new state
             self.canvas.undo_redo_manager._last_save_time = 0
-            self.canvas.undo_redo_manager.save_state()
+            self.canvas.undo_redo_manager.save_state(
+                action='strand.hidden', source='panel', detail='show',
+                targets=layer_names(self.canvas, self.multi_selected_layers))
         else:
             pass
         
@@ -2145,7 +2160,9 @@ class LayerPanel(StrandDataClipboardMixin, QWidget):
         if hasattr(self.canvas, 'undo_redo_manager') and self.canvas.undo_redo_manager:
             # Force save by resetting last save time to ensure this is captured as a new state
             self.canvas.undo_redo_manager._last_save_time = 0
-            self.canvas.undo_redo_manager.save_state()
+            self.canvas.undo_redo_manager.save_state(
+                action='strand.shadow_only', source='panel', detail='on',
+                targets=layer_names(self.canvas, self.multi_selected_layers))
         else:
             pass
         
@@ -2175,7 +2192,9 @@ class LayerPanel(StrandDataClipboardMixin, QWidget):
         if hasattr(self.canvas, 'undo_redo_manager') and self.canvas.undo_redo_manager:
             # Force save by resetting last save time to ensure this is captured as a new state
             self.canvas.undo_redo_manager._last_save_time = 0
-            self.canvas.undo_redo_manager.save_state()
+            self.canvas.undo_redo_manager.save_state(
+                action='strand.shadow_only', source='panel', detail='off',
+                targets=layer_names(self.canvas, self.multi_selected_layers))
         else:
             pass
 
@@ -2198,7 +2217,9 @@ class LayerPanel(StrandDataClipboardMixin, QWidget):
 
         # Save state BEFORE deletion for proper undo/redo
         if hasattr(self, 'undo_redo_manager') and self.undo_redo_manager:
-            self.undo_redo_manager.save_state()
+            self.undo_redo_manager.save_state(
+                action='layer.delete', source='panel', detail='before deleting',
+                targets=layer_names(self.canvas, self.multi_selected_layers))
 
         # Sort indices in descending order to delete from highest to lowest
         # This prevents index shifting issues during deletion
@@ -2224,7 +2245,8 @@ class LayerPanel(StrandDataClipboardMixin, QWidget):
 
         # Save state AFTER deletion to capture the "deleted" state
         if hasattr(self, 'undo_redo_manager') and self.undo_redo_manager:
-            self.undo_redo_manager.save_state(allow_empty=True)
+            self.undo_redo_manager.save_state(allow_empty=True,
+                                              action='layer.delete', source='panel')
 
         # Clear selections after operation
         self.multi_selected_layers.clear()
@@ -2263,7 +2285,8 @@ class LayerPanel(StrandDataClipboardMixin, QWidget):
         if hasattr(self, 'undo_redo_manager') and self.undo_redo_manager:
             # Check if we're already in a mask save operation to prevent duplicates
             if not getattr(self.undo_redo_manager, '_mask_save_in_progress', False):
-                self.undo_redo_manager.save_state()
+                self.undo_redo_manager.save_state(action='mask.create', source='panel',
+                                                  detail='left mask mode')
             else:
                 pass
 
@@ -2300,7 +2323,8 @@ class LayerPanel(StrandDataClipboardMixin, QWidget):
             # Force save by temporarily clearing the last save time to bypass timing check
             old_last_save_time = getattr(self.undo_redo_manager, '_last_save_time', 0)
             self.undo_redo_manager._last_save_time = 0
-            self.undo_redo_manager.save_state()
+            self.undo_redo_manager.save_state(action='layer.lock_mode', source='panel',
+                                              detail='on' if self.lock_mode else 'off')
             # Restore the last save time
             self.undo_redo_manager._last_save_time = old_last_save_time
 
@@ -2369,7 +2393,10 @@ class LayerPanel(StrandDataClipboardMixin, QWidget):
             # Force save by temporarily clearing the last save time to bypass timing check
             old_last_save_time = getattr(self.undo_redo_manager, '_last_save_time', 0)
             self.undo_redo_manager._last_save_time = 0
-            self.undo_redo_manager.save_state()
+            self.undo_redo_manager.save_state(
+                action='layer.lock', source='panel',
+                targets=layer_names(self.canvas, [index]),
+                detail='locked' if index in self.locked_layers else 'unlocked')
             # Restore the last save time
             self.undo_redo_manager._last_save_time = old_last_save_time
 
@@ -2642,7 +2669,8 @@ class LayerPanel(StrandDataClipboardMixin, QWidget):
         if hasattr(self, 'undo_redo_manager') and self.undo_redo_manager:
             # Force a save by resetting the last save time so the identical-state and timing checks are bypassed
             self.undo_redo_manager._last_save_time = 0
-            self.undo_redo_manager.save_state()
+            self.undo_redo_manager.save_state(action='mask.edit', source='panel',
+                                              detail='left mask edit mode')
         # --- END ADD ---
 
     def disable_controls(self):
@@ -2764,7 +2792,9 @@ class LayerPanel(StrandDataClipboardMixin, QWidget):
                 if isinstance(strand, MaskedStrand):
                     # Save state BEFORE deletion for proper undo/redo
                     if hasattr(self, 'undo_redo_manager') and self.undo_redo_manager:
-                        self.undo_redo_manager.save_state()
+                        self.undo_redo_manager.save_state(
+                            action='layer.delete', source='panel', targets=[strand_name],
+                            detail='before deleting the mask')
 
                     # Delete only this specific masked layer
                     if self.canvas.delete_masked_layer(strand):
@@ -2775,12 +2805,16 @@ class LayerPanel(StrandDataClipboardMixin, QWidget):
 
                         # Save state AFTER deletion to capture the "deleted" state
                         if hasattr(self, 'undo_redo_manager') and self.undo_redo_manager:
-                            self.undo_redo_manager.save_state(allow_empty=True)
+                            self.undo_redo_manager.save_state(
+                                allow_empty=True, action='layer.delete', source='panel',
+                                targets=[strand_name], detail='mask deleted')
 
                 else:
                     # Save state BEFORE deletion for proper undo/redo
                     if hasattr(self, 'undo_redo_manager') and self.undo_redo_manager:
-                        self.undo_redo_manager.save_state()
+                        self.undo_redo_manager.save_state(
+                            action='layer.delete', source='panel', targets=[strand_name],
+                            detail='before deleting')
 
                     # Handle regular strand deletion
                     self.strand_deleted.emit(strand_index)
@@ -2791,7 +2825,9 @@ class LayerPanel(StrandDataClipboardMixin, QWidget):
 
                     # Save state AFTER deletion to capture the "deleted" state
                     if hasattr(self, 'undo_redo_manager') and self.undo_redo_manager:
-                        self.undo_redo_manager.save_state(allow_empty=True)
+                        self.undo_redo_manager.save_state(
+                            allow_empty=True, action='layer.delete', source='panel',
+                            targets=[strand_name], detail='deleted')
             else:
                 pass
         else:
@@ -3157,7 +3193,7 @@ class LayerPanel(StrandDataClipboardMixin, QWidget):
             
             # Save state for undo/redo
             if hasattr(self, 'undo_redo_manager') and self.undo_redo_manager:
-                self.undo_redo_manager.save_state()
+                self.undo_redo_manager.save_state(action='layer.clear_locks', source='panel')
             
             # Update canvas to reflect changes
             self.canvas.update()
@@ -3208,7 +3244,8 @@ class LayerPanel(StrandDataClipboardMixin, QWidget):
         if msg_box.clickedButton() == yes_button:
             # Save state for undo before deleting
             if hasattr(self, 'undo_redo_manager') and self.undo_redo_manager:
-                self.undo_redo_manager.save_state()
+                self.undo_redo_manager.save_state(action='layer.delete_all', source='panel',
+                                                  detail='before clearing')
 
             # Clear all strands from canvas
             self.canvas.strands.clear()
@@ -3248,7 +3285,8 @@ class LayerPanel(StrandDataClipboardMixin, QWidget):
 
             # Save state AFTER deletion to capture the "deleted" state for redo
             if hasattr(self, 'undo_redo_manager') and self.undo_redo_manager:
-                self.undo_redo_manager.save_state(allow_empty=True)
+                self.undo_redo_manager.save_state(allow_empty=True, action='layer.delete_all',
+                                                  source='panel')
 
     def on_color_changed(self, set_number, color):
         """Handle color change for a set of strands."""
@@ -3292,7 +3330,8 @@ class LayerPanel(StrandDataClipboardMixin, QWidget):
             if not getattr(self.undo_redo_manager, '_suppress_intermediate_saves', False):
                 # Reset last save time to force save, as color change alone might not be detected otherwise
                 self.undo_redo_manager._last_save_time = 0 
-                self.undo_redo_manager.save_state()
+                self.undo_redo_manager.save_state(action='strand.color', source='dialog',
+                                                  detail='set {}'.format(set_number))
             else:
                 pass
             # --- END ADD --- 
@@ -3987,7 +4026,8 @@ class LayerPanel(StrandDataClipboardMixin, QWidget):
                     self.group_layer_manager.refresh(),
                     self.scroll_layout.update(),
                     self.canvas.update(),
-                    self.undo_redo_manager.save_state() if hasattr(self, 'undo_redo_manager') and self.undo_redo_manager else None
+                    self.undo_redo_manager.save_state(action='layer.reorder', source='panel')
+                    if hasattr(self, 'undo_redo_manager') and self.undo_redo_manager else None
                 ))
             else:
                 # non‑macOS path: execute immediately
@@ -3997,7 +4037,7 @@ class LayerPanel(StrandDataClipboardMixin, QWidget):
                 self.scroll_layout.update()
                 self.canvas.update()
                 if hasattr(self, 'undo_redo_manager') and self.undo_redo_manager:
-                    self.undo_redo_manager.save_state()
+                    self.undo_redo_manager.save_state(action='layer.reorder', source='panel')
 
 
         else:

--- a/src/main_window.py
+++ b/src/main_window.py
@@ -2832,7 +2832,9 @@ class MainWindow(QMainWindow):
             if hasattr(self.canvas, 'undo_redo_manager') and self.canvas.undo_redo_manager:
                 # Force immediate save to capture this state change
                 self.canvas.undo_redo_manager._last_save_time = 0
-                self.canvas.undo_redo_manager.save_state()
+                self.canvas.undo_redo_manager.save_state(
+                    action='system.setting', source='panel',
+                    detail='control points ' + ('on' if current_state else 'off'))
                 pass
         
         # Update all strands' control points visibility

--- a/src/mask_grid_dialog.py
+++ b/src/mask_grid_dialog.py
@@ -658,7 +658,9 @@ class MaskGridDialog(QDialog):
                 setattr(undo_redo_manager, '_skip_save', False)
                 setattr(undo_redo_manager, '_mask_save_in_progress', False)
                 # Save state once for all masks created
-                undo_redo_manager.save_state()
+                undo_redo_manager.save_state(
+                    action='mask.create', source='dialog',
+                    detail='{} pairs from the mask grid'.format(len(mask_pairs)))
 
     def _refresh_table(self):
         """Refresh the table to reflect current mask state (both created and deleted masks)."""

--- a/src/numbered_layer_button.py
+++ b/src/numbered_layer_button.py
@@ -3347,17 +3347,22 @@ class NumberedLayerButton(QPushButton):
                 if hasattr(strand, 'layer_name') and strand.layer_name:
                     set_prefix = f"{strand.layer_name.split('_')[0]}_"
 
+                recolored = []
                 if set_prefix and layer_panel and hasattr(layer_panel, 'canvas'):
                     for other_strand in layer_panel.canvas.strands:
                         if (hasattr(other_strand, 'layer_name')
                                 and other_strand.layer_name
                                 and other_strand.layer_name.startswith(set_prefix)):
                             self._apply_stroke_color(other_strand, color)
+                            recolored.append(other_strand.layer_name)
                 else:
                     self._apply_stroke_color(strand, color)
+                    recolored.append(getattr(strand, 'layer_name', self.text()))
 
+                # Name every layer that changed colour, not just the clicked one.
                 self._refresh_canvas_and_save(
-                    layer_panel, action='strand.color', detail='stroke, whole set')
+                    layer_panel, action='strand.color', targets=recolored,
+                    detail='stroke, whole set')
 
     def change_layer_stroke_color(self, strand, layer_panel):
         """Change the stroke color of only the clicked strand layer."""
@@ -3717,9 +3722,12 @@ class NumberedLayerButton(QPushButton):
         # Save state for undo/redo functionality
         if hasattr(layer_panel.canvas, 'undo_redo_manager'):
             # Use a small delay to ensure all knot properties are established
+            # Both ends of the knot are rewritten here, so both are recorded.
+            knot_targets = [getattr(strand, 'layer_name', None),
+                            getattr(target_strand, 'layer_name', None)]
             QTimer.singleShot(50, lambda: layer_panel.canvas.undo_redo_manager.save_state(
                 action='strand.close_knot', source='menu',
-                targets=[getattr(strand, 'layer_name', None)], detail=free_end_type))
+                targets=knot_targets, detail=free_end_type))
         
     
     def change_width(self, strand, layer_panel):
@@ -3741,6 +3749,9 @@ class NumberedLayerButton(QPushButton):
                 strand.update_shape()
             
             # Find and update related strands with the same set number (like color changes)
+            # Declared out here so the history entry below can name every layer
+            # the loop actually resized, not just the one that was clicked.
+            updated_strands = []
             if hasattr(strand, 'layer_name') and strand.layer_name:
                 layer_parts = strand.layer_name.split('_')
                 if len(layer_parts) >= 1:
@@ -3748,7 +3759,6 @@ class NumberedLayerButton(QPushButton):
                     set_prefix = f"{set_number}_"
                     
                     # Update all strands that belong to the same set
-                    updated_strands = []
                     grid_units_value = dialog.thickness_spinbox.value()
                     for other_strand in layer_panel.canvas.strands:
                         if (hasattr(other_strand, 'layer_name') and 
@@ -3779,7 +3789,8 @@ class NumberedLayerButton(QPushButton):
                     # Save the state
                     layer_panel.canvas.undo_redo_manager.save_state(
                         action='strand.width', source='dialog',
-                        targets=[getattr(strand, 'layer_name', None)], detail='whole set')
+                        targets=updated_strands or [getattr(strand, 'layer_name', None)],
+                        detail='whole set')
                     # Check if save actually happened
                     new_step = layer_panel.canvas.undo_redo_manager.current_step
                     if new_step > current_step:

--- a/src/numbered_layer_button.py
+++ b/src/numbered_layer_button.py
@@ -1663,7 +1663,9 @@ class NumberedLayerButton(QPushButton):
                 if hasattr(layer_panel.canvas, 'undo_redo_manager'):
                     # Force save with detailed logging
                     layer_panel.canvas.undo_redo_manager._last_save_time = 0
-                    layer_panel.canvas.undo_redo_manager.save_state()
+                    layer_panel.canvas.undo_redo_manager.save_state(
+                        action='strand.arrow_style', source='dialog',
+                        targets=[self.text()], detail='arrow sizes')
             elif not state_changed:
                 pass
     def setText(self, text):
@@ -1851,7 +1853,9 @@ class NumberedLayerButton(QPushButton):
                     parent = parent.parent()
 
                 if layer_panel and hasattr(layer_panel.canvas, 'undo_redo_manager') and layer_panel.canvas.undo_redo_manager:
-                    layer_panel.canvas.undo_redo_manager.save_state()
+                    layer_panel.canvas.undo_redo_manager.save_state(
+                        action='strand.hidden', source='menu', targets=[self.text()],
+                        detail='hidden' if hidden else 'shown')
                 else:
                     pass
             except Exception as e:
@@ -2185,7 +2189,8 @@ class NumberedLayerButton(QPushButton):
                     canvas.undo_redo_manager._last_save_time = 0
                     if hasattr(canvas.undo_redo_manager, '_skip_save'):
                         canvas.undo_redo_manager._skip_save = False
-                    canvas.undo_redo_manager.save_state()
+                    canvas.undo_redo_manager.save_state(
+                        action='strand.circle_stroke', source='menu', targets=[self.text()])
 
     def set_end_circle_stroke_color(self, color):
         """
@@ -2268,7 +2273,9 @@ class NumberedLayerButton(QPushButton):
                             current_parent.canvas.undo_redo_manager._last_save_time = 0
                             if hasattr(current_parent.canvas.undo_redo_manager, '_skip_save'):
                                 current_parent.canvas.undo_redo_manager._skip_save = False
-                            current_parent.canvas.undo_redo_manager.save_state()
+                            current_parent.canvas.undo_redo_manager.save_state(
+                                action='strand.end_circle_stroke', source='menu',
+                                targets=[self.text()])
                         
                         break
                     current_parent = current_parent.parent()
@@ -2889,7 +2896,10 @@ class NumberedLayerButton(QPushButton):
             # Save state before opening dialog for undo/redo
             if hasattr(layer_panel.canvas, 'undo_redo_manager') and layer_panel.canvas.undo_redo_manager:
                 layer_panel.canvas.undo_redo_manager._last_save_time = 0
-                layer_panel.canvas.undo_redo_manager.save_state()
+                layer_panel.canvas.undo_redo_manager.save_state(
+                    action='strand.shadow', source='dialog',
+                    targets=[getattr(strand, 'layer_name', None)],
+                    detail='before opening the shadow editor')
 
             # Create and show the shadow editor dialog
             dialog = ShadowEditorDialog(layer_panel.canvas, strand, parent=layer_panel)
@@ -3003,7 +3013,8 @@ class NumberedLayerButton(QPushButton):
                 # Save state for undo/redo to persist the circle stroke color change
                 if hasattr(layer_panel.canvas, 'undo_redo_manager'):
                     layer_panel.canvas.undo_redo_manager._last_save_time = 0
-                    layer_panel.canvas.undo_redo_manager.save_state()
+                    layer_panel.canvas.undo_redo_manager.save_state(
+                        action='strand.circle_stroke', source='menu', targets=[self.text()])
             else:
                 # Fall back to just updating ourselves or the parent widget
                 self.update()
@@ -3025,7 +3036,10 @@ class NumberedLayerButton(QPushButton):
                     layer_panel.canvas.undo_redo_manager._last_save_time = 0 
                     print(f"Reset _last_save_time to force save for toggling {attr_name}")
                     # --- END ADD ---
-                    layer_panel.canvas.undo_redo_manager.save_state() # save_state is called AFTER changing the attribute
+                    layer_panel.canvas.undo_redo_manager.save_state(
+                        action='strand.line_visible', source='menu',
+                        targets=[getattr(strand, 'layer_name', None)],
+                        detail=attr_name)  # save_state is called AFTER changing the attribute
                     print(f"Undo/Redo state saved after toggling {attr_name}")
                 else:
                     print("Warning: Could not find undo_redo_manager on canvas to save state.")
@@ -3194,7 +3208,10 @@ class NumberedLayerButton(QPushButton):
                     layer_panel.canvas.undo_redo_manager._last_save_time = 0 
                     print(f"Reset _last_save_time to force save for toggling {attr_name}")
                     # --- END ADD ---
-                    layer_panel.canvas.undo_redo_manager.save_state() # save_state is called AFTER changing the attribute
+                    layer_panel.canvas.undo_redo_manager.save_state(
+                        action='strand.extension', source='menu',
+                        targets=[getattr(strand, 'layer_name', None)],
+                        detail=attr_name)  # save_state is called AFTER changing the attribute
                     print(f"Undo/Redo state saved after toggling {attr_name}")
                 else:
                     print("Warning: Could not find undo_redo_manager on canvas to save state.")
@@ -3221,7 +3238,10 @@ class NumberedLayerButton(QPushButton):
                     layer_panel.canvas.undo_redo_manager._last_save_time = 0 
                     print(f"Reset _last_save_time to force save for toggling {attr_name}")
                     # --- END ADD ---
-                    layer_panel.canvas.undo_redo_manager.save_state() # save_state is called AFTER changing the attribute
+                    layer_panel.canvas.undo_redo_manager.save_state(
+                        action='strand.arrow', source='menu',
+                        targets=[getattr(strand, 'layer_name', None)],
+                        detail=attr_name)  # save_state is called AFTER changing the attribute
                     print(f"Undo/Redo state saved after toggling {attr_name}")
                 else:
                     print("Warning: Could not find undo_redo_manager on canvas to save state.")
@@ -3281,7 +3301,9 @@ class NumberedLayerButton(QPushButton):
             # Save state for undo/redo if manager exists
             if hasattr(layer_panel.canvas, 'undo_redo_manager'):
                 layer_panel.canvas.undo_redo_manager._last_save_time = 0
-                layer_panel.canvas.undo_redo_manager.save_state()
+                layer_panel.canvas.undo_redo_manager.save_state(
+                    action='strand.circle_visible', source='menu',
+                    targets=[getattr(strand, 'layer_name', None)], detail=circle_type)
         else:
             self.update()
     # --- END NEW ---
@@ -3334,7 +3356,8 @@ class NumberedLayerButton(QPushButton):
                 else:
                     self._apply_stroke_color(strand, color)
 
-                self._refresh_canvas_and_save(layer_panel)
+                self._refresh_canvas_and_save(
+                    layer_panel, action='strand.color', detail='stroke, whole set')
 
     def change_layer_stroke_color(self, strand, layer_panel):
         """Change the stroke color of only the clicked strand layer."""
@@ -3371,7 +3394,8 @@ class NumberedLayerButton(QPushButton):
             color = color_dialog.currentColor()
             if color.isValid():
                 self._apply_stroke_color(strand, color)
-                self._refresh_canvas_and_save(layer_panel)
+                self._refresh_canvas_and_save(
+                    layer_panel, action='strand.color', detail='stroke, this layer only')
 
     def change_layer_color(self, strand, layer_panel):
         """Change the fill color of only the clicked strand layer."""
@@ -3414,7 +3438,8 @@ class NumberedLayerButton(QPushButton):
                 # Only this layer button changes. Set-level color maps remain the
                 # source of truth for future strands in the set.
                 self.set_color(color)
-                self._refresh_canvas_and_save(layer_panel)
+                self._refresh_canvas_and_save(
+                    layer_panel, action='strand.color', detail='fill, this layer only')
 
     @staticmethod
     def _apply_stroke_color(strand, color):
@@ -3442,8 +3467,14 @@ class NumberedLayerButton(QPushButton):
                 and strand.circle_stroke_color.alpha() > 0):
             strand.circle_stroke_color = QColor(color)
 
-    def _refresh_canvas_and_save(self, layer_panel):
-        """Repaint the canvas and force an undo/redo snapshot."""
+    def _refresh_canvas_and_save(self, layer_panel, action='strand.color',
+                                 source='menu', targets=None, detail=None):
+        """Repaint the canvas and force an undo/redo snapshot.
+
+        The action/source/targets/detail describe what the caller just changed;
+        they are recorded with the state so the history says which menu entry
+        produced it (see undo_redo_metadata.py).
+        """
         if layer_panel and hasattr(layer_panel, 'canvas'):
             if (hasattr(layer_panel.canvas, 'layer_state_manager')
                     and layer_panel.canvas.layer_state_manager):
@@ -3452,7 +3483,10 @@ class NumberedLayerButton(QPushButton):
             if (hasattr(layer_panel.canvas, 'undo_redo_manager')
                     and layer_panel.canvas.undo_redo_manager):
                 layer_panel.canvas.undo_redo_manager._last_save_time = 0
-                layer_panel.canvas.undo_redo_manager.save_state()
+                layer_panel.canvas.undo_redo_manager.save_state(
+                    action=action, source=source,
+                    targets=targets if targets is not None else [self.text()],
+                    detail=detail)
         else:
             self.update()
 
@@ -3683,7 +3717,9 @@ class NumberedLayerButton(QPushButton):
         # Save state for undo/redo functionality
         if hasattr(layer_panel.canvas, 'undo_redo_manager'):
             # Use a small delay to ensure all knot properties are established
-            QTimer.singleShot(50, lambda: layer_panel.canvas.undo_redo_manager.save_state())
+            QTimer.singleShot(50, lambda: layer_panel.canvas.undo_redo_manager.save_state(
+                action='strand.close_knot', source='menu',
+                targets=[getattr(strand, 'layer_name', None)], detail=free_end_type))
         
     
     def change_width(self, strand, layer_panel):
@@ -3741,7 +3777,9 @@ class NumberedLayerButton(QPushButton):
                     # Get current step before saving
                     current_step = layer_panel.canvas.undo_redo_manager.current_step
                     # Save the state
-                    layer_panel.canvas.undo_redo_manager.save_state()
+                    layer_panel.canvas.undo_redo_manager.save_state(
+                        action='strand.width', source='dialog',
+                        targets=[getattr(strand, 'layer_name', None)], detail='whole set')
                     # Check if save actually happened
                     new_step = layer_panel.canvas.undo_redo_manager.current_step
                     if new_step > current_step:
@@ -3787,7 +3825,9 @@ class NumberedLayerButton(QPushButton):
                 # Save state for undo/redo
                 if hasattr(layer_panel.canvas, 'undo_redo_manager'):
                     layer_panel.canvas.undo_redo_manager._last_save_time = 0
-                    layer_panel.canvas.undo_redo_manager.save_state()
+                    layer_panel.canvas.undo_redo_manager.save_state(
+                        action='strand.width', source='dialog',
+                        targets=[getattr(strand, 'layer_name', None)], detail='this layer only')
 
     def _refresh_dependent_masks(self, strand, layer_panel):
         """Recalculate any MaskedStrand that uses `strand` as a component.
@@ -3886,7 +3926,10 @@ class NumberedLayerButton(QPushButton):
             layer_panel.canvas.update()
             if hasattr(layer_panel.canvas, 'undo_redo_manager'):
                 layer_panel.canvas.undo_redo_manager._last_save_time = 0
-                layer_panel.canvas.undo_redo_manager.save_state()
+                layer_panel.canvas.undo_redo_manager.save_state(
+                    action='strand.arrow_style', source='menu',
+                    targets=[getattr(strand, 'layer_name', None)],
+                    detail='casts shadow' if casts_shadow else 'no shadow')
     # --- END Arrow Customization Methods ---
 
 

--- a/src/rotate_mode.py
+++ b/src/rotate_mode.py
@@ -94,7 +94,9 @@ class RotateMode:
         if self.is_rotating:  # Only save state if we were actually rotating
             # Save state for undo/redo after rotation
             if hasattr(self.canvas, 'layer_panel') and hasattr(self.canvas.layer_panel, 'undo_redo_manager'):
-                self.canvas.layer_panel.undo_redo_manager.save_state()
+                self.canvas.layer_panel.undo_redo_manager.save_state(
+                    action='rotate.strand', source='mode',
+                    targets=[getattr(getattr(self, 'affected_strand', None), 'layer_name', None)])
 
         # Reset all properties
         self.is_rotating = False

--- a/src/settings_dialog.py
+++ b/src/settings_dialog.py
@@ -13,6 +13,8 @@ from PyQt5.QtMultimedia import QMediaPlayer, QMediaContent
 from PyQt5.QtMultimediaWidgets import QVideoWidget
 from translations import translations
 from save_load_manager import load_strands, apply_loaded_strands
+# Reads the provenance recorded with each undo/redo state, for the History page.
+from undo_redo_metadata import describe as describe_history, read_metadata as read_history_metadata
 from segmented_spin_box import upgrade_and_style_all, upgrade_spinbox, style_segmented_spinbox
 import os
 import sys
@@ -3347,6 +3349,22 @@ class SettingsDialog(QDialog):
             self.history_list.setLayoutDirection(Qt.LeftToRight)
         self.history_list.setToolTip(_['history_list_tooltip'] if 'history_list_tooltip' in _ else "Select a session to load its final state")
         history_layout.addWidget(self.history_list)
+
+        # What was actually DONE, not just how many states exist. With no session
+        # selected this lists the current session's activity (every edit, undo and
+        # redo in order); selecting a past session lists what produced each of its
+        # saved states. See undo_redo_metadata.py.
+        self.history_actions_label = QLabel(_['history_actions'])
+        if self.is_rtl_language(self.current_language):
+            history_layout.addWidget(self.history_actions_label, 0, Qt.AlignLeft)
+        else:
+            history_layout.addWidget(self.history_actions_label)
+
+        self.history_actions_list = QListWidget()
+        if self.is_rtl_language(self.current_language):
+            self.history_actions_list.setLayoutDirection(Qt.LeftToRight)
+        self.history_actions_list.setSelectionMode(QListWidget.NoSelection)
+        history_layout.addWidget(self.history_actions_list)
         
         # Move the populate_history_list call to after button creation
         # self.populate_history_list() - Removing this call from here
@@ -3356,6 +3374,7 @@ class SettingsDialog(QDialog):
         self.load_history_button.clicked.connect(self.load_selected_history)
         self.load_history_button.setEnabled(False) # Disable initially
         self.history_list.currentItemChanged.connect(lambda item: self.load_history_button.setEnabled(item is not None))
+        self.history_list.currentItemChanged.connect(lambda item: self.populate_history_actions(item))
 
         self.clear_history_button = QPushButton(_['clear_all_history'])
         self.clear_history_button.clicked.connect(self.clear_all_history_action)
@@ -3368,6 +3387,7 @@ class SettingsDialog(QDialog):
         
         # Call populate_history_list after creating all the UI elements it needs
         self.populate_history_list()
+        self.populate_history_actions()
         
         self.stacked_widget.addWidget(self.history_widget)
 
@@ -5146,8 +5166,10 @@ class SettingsDialog(QDialog):
         self.load_history_button.setText(_['load_selected_history'])
         self.clear_history_button.setText(_['clear_all_history'])
         self.history_list.setToolTip(_['history_list_tooltip'] if 'history_list_tooltip' in _ else "Select a session to load its final state")
+        self.history_actions_label.setText(_['history_actions'])
         # Refresh history list to apply new language translations and RTL formatting
         self.populate_history_list()
+        self.populate_history_actions(self.history_list.currentItem())
         # Update What's New page elements
         self.whats_new_text_browser.setHtml(self.render_whats_new_html(_['whats_new_info']))
         # Update about text browser instead of label
@@ -6821,6 +6843,55 @@ class SettingsDialog(QDialog):
                     self.history_list.addItem(item)
             self.clear_history_button.setEnabled(True) # Enable clear if history exists
             
+    def populate_history_actions(self, selected_item=None):
+        """List what was done — this session's activity, or a past session's.
+
+        With no session selected this shows the running journal of the current
+        session (edits, undos and redos, newest first). With one selected it
+        reads the provenance recorded inside that session's state files, which
+        is why a recovered session can still say what produced each step.
+        """
+        if not hasattr(self, 'history_actions_list'):
+            return
+        _ = translations[self.current_language]
+        self.history_actions_list.clear()
+
+        rows = []
+        if selected_item is not None and self.undo_redo_manager:
+            filepath = selected_item.data(Qt.UserRole)
+            if filepath:
+                directory = os.path.dirname(filepath)
+                session_id = os.path.basename(filepath).split('_')[0]
+                steps = []
+                try:
+                    for filename in os.listdir(directory):
+                        if not filename.startswith(session_id + '_') or not filename.endswith('.json'):
+                            continue
+                        try:
+                            step = int(filename[len(session_id) + 1:-len('.json')])
+                        except ValueError:
+                            continue
+                        steps.append((step, os.path.join(directory, filename)))
+                except OSError:
+                    steps = []
+                for step, path in sorted(steps, reverse=True):
+                    rows.append("{}. {}".format(step, describe_history(read_history_metadata(path))))
+        elif self.undo_redo_manager:
+            for event in reversed(self.undo_redo_manager.get_session_journal()):
+                prefix = {'undo': 'Undo: ', 'redo': 'Redo: '}.get(event['kind'], '')
+                rows.append("{}  {}{}".format(event['at'], prefix, event['description']))
+
+        if not rows:
+            self.history_actions_list.addItem(_['no_actions_recorded'])
+            return
+        for row in rows:
+            item = QListWidgetItem(row)
+            if self.is_rtl_language(self.current_language):
+                item.setTextAlignment(Qt.AlignRight | Qt.AlignVCenter)
+            else:
+                item.setTextAlignment(Qt.AlignLeft | Qt.AlignVCenter)
+            self.history_actions_list.addItem(item)
+
     def load_selected_history(self):
         """Loads the final state of the selected history session."""
         _ = translations[self.current_language]

--- a/src/settings_dialog.py
+++ b/src/settings_dialog.py
@@ -6882,7 +6882,14 @@ class SettingsDialog(QDialog):
                 rows.append("{}  {}{}".format(event['at'], prefix, event['description']))
 
         if not rows:
-            self.history_actions_list.addItem(_['no_actions_recorded'])
+            # The placeholder is a row like any other: it takes the same
+            # alignment, or it reads left-aligned in a right-aligned list.
+            empty_item = QListWidgetItem(_['no_actions_recorded'])
+            if self.is_rtl_language(self.current_language):
+                empty_item.setTextAlignment(Qt.AlignRight | Qt.AlignVCenter)
+            else:
+                empty_item.setTextAlignment(Qt.AlignLeft | Qt.AlignVCenter)
+            self.history_actions_list.addItem(empty_item)
             return
         for row in rows:
             item = QListWidgetItem(row)

--- a/src/shadow_editor_dialog.py
+++ b/src/shadow_editor_dialog.py
@@ -1301,6 +1301,8 @@ class ShadowEditorDialog(QDialog):
         # Save state for undo/redo when dialog closes
         if hasattr(self.canvas, 'undo_redo_manager') and self.canvas.undo_redo_manager:
             self.canvas.undo_redo_manager._last_save_time = 0
-            self.canvas.undo_redo_manager.save_state()
+            self.canvas.undo_redo_manager.save_state(
+                action='strand.shadow', source='dialog',
+                targets=[getattr(self.strand, 'layer_name', None)])
 
         super().closeEvent(event)

--- a/src/strand_data_menu.py
+++ b/src/strand_data_menu.py
@@ -427,7 +427,9 @@ class StrandDataClipboardMixin:
             targets = None
         else:
             targets = [index]
-        return self.paste_copied_strand_data(anchor, targets)
+        # The chip lives on the layer button, not in the menu — say so in the
+        # history, otherwise both routes read as a menu paste.
+        return self.paste_copied_strand_data(anchor, targets, source='panel')
 
     def _eligible_paste_indices(self, indices=None):
         candidates = self.multi_selected_layers if indices is None else indices
@@ -435,8 +437,12 @@ class StrandDataClipboardMixin:
             index for index in sorted(candidates) if self.is_strand_data_paste_target(index)
         ]
 
-    def paste_copied_strand_data(self, anchor="start", target_indices=None):
-        """Paste onto all eligible ticked layers and create one undo state."""
+    def paste_copied_strand_data(self, anchor="start", target_indices=None, source='menu'):
+        """Paste onto all eligible ticked layers and create one undo state.
+
+        `source` is the surface the paste came from, recorded with the state:
+        the copy/paste menu by default, or the layer-button chip.
+        """
         clipboard = getattr(self.canvas, "strand_clipboard", None)
         if clipboard is None:
             return 0
@@ -457,7 +463,7 @@ class StrandDataClipboardMixin:
         manager = getattr(self.canvas, "undo_redo_manager", None)
         if manager is not None:
             manager._last_save_time = 0
-            manager.save_state(action='strand.paste', source='menu',
+            manager.save_state(action='strand.paste', source=source,
                                targets=layer_names(self.canvas, changed),
                                detail='from the {} point'.format(anchor))
         return len(changed)

--- a/src/strand_data_menu.py
+++ b/src/strand_data_menu.py
@@ -16,6 +16,9 @@ from PyQt5.QtWidgets import (
     QWidgetAction,
 )
 
+# Layer names for the undo/redo provenance record (call sites hold indices).
+from undo_redo_metadata import layer_names
+
 
 def _keep_menu_on_screen(menu):
     """Shift an already-open menu back inside the screen after it grew.
@@ -454,5 +457,7 @@ class StrandDataClipboardMixin:
         manager = getattr(self.canvas, "undo_redo_manager", None)
         if manager is not None:
             manager._last_save_time = 0
-            manager.save_state()
+            manager.save_state(action='strand.paste', source='menu',
+                               targets=layer_names(self.canvas, changed),
+                               detail='from the {} point'.format(anchor))
         return len(changed)

--- a/src/strand_drawing_canvas.py
+++ b/src/strand_drawing_canvas.py
@@ -517,6 +517,10 @@ class StrandDrawingCanvas(QWidget):
 
         # Set initial mode to attach
         self.current_mode = self.attach_mode
+        # The mode NAME as set_mode was called with it. current_mode is a mode
+        # object (and None while drawing a new strand), so the undo/redo
+        # provenance record reads this rather than guessing from the class.
+        self.current_mode_name = "attach"
 
         # Connect mode-specific signals (if any)
         # For example:
@@ -3073,7 +3077,9 @@ class StrandDrawingCanvas(QWidget):
         if hasattr(self, 'undo_redo_manager') and self.undo_redo_manager:
             # Force immediate save to capture this state change
             self.undo_redo_manager._last_save_time = 0
-            self.undo_redo_manager.save_state()
+            self.undo_redo_manager.save_state(
+                action='system.setting', source='panel',
+                detail='control points ' + ('on' if self.show_control_points else 'off'))
             pass
 
     def toggle_shadow(self):
@@ -3101,7 +3107,9 @@ class StrandDrawingCanvas(QWidget):
         if hasattr(self, 'undo_redo_manager') and self.undo_redo_manager:
             # Force immediate save to capture this state change
             self.undo_redo_manager._last_save_time = 0
-            self.undo_redo_manager.save_state()
+            self.undo_redo_manager.save_state(
+                action='system.setting', source='panel',
+                detail='shadow ' + ('on' if self.shadow_enabled else 'off'))
             pass
         
     def set_shadow_color(self, color):
@@ -4983,6 +4991,9 @@ class StrandDrawingCanvas(QWidget):
         self.is_angle_adjusting = False
         self.mask_mode_active = False
         self.is_drawing_new_strand = False
+
+        # Remember the name for the undo/redo provenance record.
+        self.current_mode_name = mode
 
         # Set the new mode
         if mode == "attach":
@@ -7377,7 +7388,9 @@ class StrandDrawingCanvas(QWidget):
         if hasattr(self, 'undo_redo_manager') and self.undo_redo_manager:
             # Force immediate save to capture this state change
             self.undo_redo_manager._last_save_time = 0
-            self.undo_redo_manager.save_state()
+            self.undo_redo_manager.save_state(
+                action='strand.reset_mask', source='menu',
+                targets=[getattr(strand, 'layer_name', None)])
             pass
 
         pass

--- a/src/translations.py
+++ b/src/translations.py
@@ -558,6 +558,8 @@ Examples:<br>
         'history_cleared_title': 'History Cleared',
         'history_cleared_text': 'All past history sessions have been cleared.',
         'no_history_found': 'No past history sessions found.',
+        'history_actions': 'Recorded actions',
+        'no_actions_recorded': 'No actions recorded yet.',
         'history_explanation': 'Select a past session and click "Load Selected" to restore its final state.\nWarning: Loading history will clear your current undo/redo steps.',
         'history_list_tooltip': 'Select a session to load its final state',
         'history_state_label': 'State',  # For history list display
@@ -1046,6 +1048,8 @@ Exemples :<br>
         'history_cleared_title': 'Historique Effacé',
         'history_cleared_text': 'Toutes les sessions d\'historique passées ont été effacées.',
         'no_history_found': 'Aucune session d\'historique passée trouvée.',
+        'history_actions': 'Actions enregistrées',
+        'no_actions_recorded': 'Aucune action enregistrée pour l\'instant.',
         'history_explanation': 'Sélectionnez une session passée et cliquez sur "Charger Sélection" pour restaurer son état final.\nAttention : Le chargement de l\'historique effacera vos étapes annuler/rétablir actuelles.',
    
         'history_list_tooltip': 'Sélectionnez une session à charger dans son état final',
@@ -1685,6 +1689,8 @@ Beispiele:<br>
         'history_cleared_title': 'Verlauf gelöscht',
         'history_cleared_text': 'Alle bisherigen Verlaufssitzungen wurden gelöscht.',
         'no_history_found': 'Keine bisherigen Verlaufssitzungen gefunden.',
+        'history_actions': 'Aufgezeichnete Aktionen',
+        'no_actions_recorded': 'Noch keine Aktionen aufgezeichnet.',
         'history_explanation': 'Wählen Sie eine frühere Sitzung aus und klicken Sie auf "Ausgewählten laden", um den Endzustand wiederherzustellen.\nWarnung: Das Laden des Verlaufs löscht Ihre aktuellen Rückgängig/Wiederholen-Schritte.',
         'history_list_tooltip': 'Eine Sitzung auswählen, um ihren Endzustand zu laden',
         'history_state_label': 'Zustand',  # For history list display
@@ -2209,6 +2215,8 @@ Esempi:<br>
         'history_cleared_title': 'Cronologia Cancellata',
         'history_cleared_text': 'Tutte le sessioni di cronologia passate sono state cancellate.',
         'no_history_found': 'Nessuna sessione di cronologia passata trovata.',
+        'history_actions': 'Azioni registrate',
+        'no_actions_recorded': 'Nessuna azione registrata finora.',
         'history_explanation': 'Seleziona una sessione passata e fai clic su "Carica Selezionato" per ripristinarne lo stato finale.\nAttenzione: il caricamento della cronologia cancellerà i passaggi annulla/ripristina correnti.',
         'history_list_tooltip': 'Seleziona una sessione da caricare nel suo stato finale',
         'history_state_label': 'Stato',  # For history list display
@@ -2794,6 +2802,8 @@ Ejemplos:<br>
         'history_cleared_title': 'Historial Borrado',
         'history_cleared_text': 'Todas las sesiones de historial pasadas han sido borradas.',
         'no_history_found': 'No se encontraron sesiones de historial pasadas.',
+        'history_actions': 'Acciones registradas',
+        'no_actions_recorded': 'Aún no se han registrado acciones.',
         'history_explanation': 'Selecciona una sesión pasada y haz clic en "Cargar Seleccionado" para restaurarla.\nAdvertencia: Borra deshacer/rehacer actuales.',
         'history_list_tooltip': 'Selecciona una sesión para cargar su estado final',
         'history_state_label': 'Estado',  # For history list display
@@ -3378,6 +3388,8 @@ Exemplos:<br>
         'history_cleared_title': 'Histórico Limpo',
         'history_cleared_text': 'Todas as sessões de histórico passadas foram limpas.',
         'no_history_found': 'Nenhuma sessão de histórico passada encontrada.',
+        'history_actions': 'Ações registadas',
+        'no_actions_recorded': 'Ainda não foram registadas ações.',
         'history_explanation': 'Selecione uma sessão passada e clique em "Carregar Selecionado" para restaurar seu estado final.\nAviso: Carregar histórico limpará suas etapas atuais de desfazer/refazer.',
         'history_list_tooltip': 'Selecione uma sessão para carregar seu estado final',
         'history_state_label': 'Estado',  # For history list display
@@ -3973,6 +3985,8 @@ Exemplos:<br>
         'history_cleared_title': 'היסטוריה נוקתה',
         'history_cleared_text': 'כל הפעלות ההיסטוריה הקודמות נוקו.',
         'no_history_found': 'לא נמצאו הפעלות היסטוריה קודמות.',
+        'history_actions': 'פעולות שנרשמו',
+        'no_actions_recorded': 'עדיין לא נרשמו פעולות.',
         'history_explanation': ' בחר הפעלה קודמת ולחץ "טען נבחר" כדי לשחזר את המצב הסופי שלה.\n' +
             ' אזהרה: טעינת היסטוריה תנקה את שלבי הביטול/שחזור הנוכחיים שלך.',
         'history_list_tooltip': 'בחר הפעלה לטעינת המצב הסופי שלה',

--- a/src/undo_redo_manager.py
+++ b/src/undo_redo_manager.py
@@ -1153,6 +1153,21 @@ class UndoRedoManager(QObject):
             self._state_metadata[step] = metadata
         return metadata
 
+    def _adopt_session(self, detail):
+        """Take over another session's history: its records, its journal, its log.
+
+        Both the loaded and the imported paths swap this manager onto a
+        different set of state files. Everything keyed to a session has to move
+        with it — the record cache (whose step numbers collide with the new
+        session's), and the journal, which is presented as "this session's
+        activity" and would otherwise list the actions of the session just
+        abandoned. journal_path follows session_id on its own.
+        """
+        self._reload_metadata_from_files()
+        self.history_journal = []
+        self._journal('load', build_metadata(
+            action='system.load', source='system', detail=detail, canvas=self.canvas))
+
     def _reload_metadata_from_files(self):
         """Rebuild the cache from the state files on disk (after an import)."""
         self._state_metadata = {}
@@ -2618,7 +2633,8 @@ class UndoRedoManager(QObject):
                 # step numbers collide with the loaded session's, and the cache
                 # is preferred over the files, so it has to be rebuilt from the
                 # states now on disk or every label would name the wrong edit.
-                self._reload_metadata_from_files()
+                self._adopt_session(
+                    'session {} at step {}'.format(loaded_session_id, loaded_step))
 
                 # Refresh UI
                 if hasattr(self.layer_panel, 'refresh'):
@@ -3166,7 +3182,7 @@ class UndoRedoManager(QObject):
 
             # The recreated files carry their own provenance — read it back so
             # an imported history still says what produced each step.
-            self._reload_metadata_from_files()
+            self._adopt_session('imported history, {} steps'.format(self.max_step))
 
             # Update UI buttons
             self._update_button_states()

--- a/src/undo_redo_manager.py
+++ b/src/undo_redo_manager.py
@@ -353,7 +353,6 @@ class UndoRedoManager(QObject):
         # state files.
         self._state_metadata = {}
         self.history_journal = []
-        self.journal_path = os.path.join(self.temp_dir, f"{self.session_id}_history.log")
         
         # Connect signals
         self.undo_performed.connect(self._update_button_states)
@@ -369,6 +368,16 @@ class UndoRedoManager(QObject):
         temp_dir = os.path.join(base_path, "temp_states")
         os.makedirs(temp_dir, exist_ok=True)
         return temp_dir
+
+    @property
+    def journal_path(self):
+        """The readable history log for the CURRENT session.
+
+        Derived rather than stored: load_specific_state adopts another
+        session's id mid-run, and a path frozen at construction would keep
+        appending this session's lines to the old session's log.
+        """
+        return os.path.join(self.temp_dir, f"{self.session_id}_history.log")
 
     def _get_state_filename(self, step):
         """Generate a filename for the specified step."""
@@ -2602,6 +2611,12 @@ class UndoRedoManager(QObject):
                 # Set the step pointers to match the loaded state
                 self.current_step = loaded_step
                 self.max_step = max_step
+
+                # The cached provenance describes the session we just left. Its
+                # step numbers collide with the loaded session's, and the cache
+                # is preferred over the files, so it has to be rebuilt from the
+                # states now on disk or every label would name the wrong edit.
+                self._reload_metadata_from_files()
 
                 # Refresh UI
                 if hasattr(self.layer_panel, 'refresh'):

--- a/src/undo_redo_manager.py
+++ b/src/undo_redo_manager.py
@@ -1132,7 +1132,9 @@ class UndoRedoManager(QObject):
         """
         entry = {"kind": kind, "meta": metadata, "at": datetime.now().isoformat(timespec="seconds")}
         self.history_journal.append(entry)
-        append_journal(self.journal_path, kind, metadata)
+        # The log line is stamped with when this happened, not when the state it
+        # names was created — an undo replays a record made minutes earlier.
+        append_journal(self.journal_path, kind, metadata, entry["at"])
         return entry
 
     def metadata_for_step(self, step):

--- a/src/undo_redo_manager.py
+++ b/src/undo_redo_manager.py
@@ -17,6 +17,11 @@ from PyQt5.QtCore import QTimer
 # We'll work with instances that are already created
 from masked_strand import MaskedStrand
 from attached_strand import AttachedStrand
+# Provenance of each saved state: which mode / panel / dialog produced it.
+from undo_redo_metadata import (
+    ACTIONS, append_journal, build_metadata, describe, read_metadata, short_label,
+    write_metadata,
+)
 
 # StrokeTextButton class incorporated directly into this file
 class StrokeTextButton(QPushButton):
@@ -339,6 +344,16 @@ class UndoRedoManager(QObject):
         self.session_id = datetime.now().strftime("%Y%m%d%H%M%S")
         self.undo_button = None
         self.redo_button = None
+
+        # Provenance (undo_redo_metadata.py). `_state_metadata` maps a step to
+        # the record of what created it — the authoritative copy lives inside
+        # the step's own JSON file, this is the read cache. `history_journal`
+        # is the session's running record of everything done, the undos and
+        # redos included, and it is mirrored to a readable log next to the
+        # state files.
+        self._state_metadata = {}
+        self.history_journal = []
+        self.journal_path = os.path.join(self.temp_dir, f"{self.session_id}_history.log")
         
         # Connect signals
         self.undo_performed.connect(self._update_button_states)
@@ -359,11 +374,18 @@ class UndoRedoManager(QObject):
         """Generate a filename for the specified step."""
         return os.path.join(self.temp_dir, f"{self.session_id}_{step}.json")
 
-    def save_state(self, allow_empty=False):
-        """Save the current state of strands and groups for undo/redo."""
+    def save_state(self, allow_empty=False, action=None, source=None, targets=None, detail=None):
+        """Save the current state of strands and groups for undo/redo.
+
+        The optional action/source/targets/detail describe WHAT is being saved —
+        the menu entry, dialog or panel button behind this state. Callers that
+        say nothing still get a record: the active mode and the calling function
+        are always captured, so no state is completely anonymous.
+        """
         # Add debug logging to track save_state calls
         import traceback
         caller_info = traceback.extract_stack()[-2]  # Get the caller info
+        origin = "{}:{}".format(os.path.basename(caller_info.filename), caller_info.name)
         
         # Check skip_save flag
         skip_save = getattr(self, '_skip_save', False)
@@ -408,10 +430,17 @@ class UndoRedoManager(QObject):
         self.current_step += 1
         self.max_step = self.current_step
         
+        # Record what produced this state before writing it, so the record ends
+        # up inside the state file itself and travels with it.
+        metadata = build_metadata(action=action, source=source, targets=targets,
+                                  detail=detail, canvas=self.canvas, origin=origin)
+
         # Save the state file
-        filename = self._save_state_file(self.current_step)
+        filename = self._save_state_file(self.current_step, metadata)
         
         if filename:
+            self._state_metadata[self.current_step] = metadata
+            self._journal('edit', metadata)
             # Signal that a state was saved
             self.state_saved.emit(self.current_step)
             
@@ -419,6 +448,7 @@ class UndoRedoManager(QObject):
             self._update_button_states()
         else:
             # If save failed, revert step counter
+            self._state_metadata.pop(self.current_step, None)
             self.current_step -= 1
             if self.max_step > self.current_step:
                 self.max_step = self.current_step
@@ -1035,6 +1065,7 @@ class UndoRedoManager(QObject):
                     os.remove(filename)
             except OSError as e:
                 pass
+            self._state_metadata.pop(step, None)
         
         # Reset max_step to current_step
         self.max_step = self.current_step
@@ -1061,7 +1092,7 @@ class UndoRedoManager(QObject):
         else:
             pass
 
-    def _save_state_file(self, step):
+    def _save_state_file(self, step, metadata=None):
         """Save the current state of the canvas to a file."""
         filename = self._get_state_filename(step)
         
@@ -1071,12 +1102,108 @@ class UndoRedoManager(QObject):
                          self.canvas.groups if hasattr(self.canvas, 'groups') else {},
                          filename,
                          self.canvas)
+            # The provenance rides inside the state file, so it survives an app
+            # restart, export_history/import_history and session recovery. It is
+            # written after the snapshot and never at its expense.
+            if metadata:
+                write_metadata(filename, metadata)
             self.state_saved.emit(step)
             return True
         except Exception as e:
             return False
 
+    # ---------------------------------------------------------------- history record
+
+    def _journal(self, kind, metadata):
+        """Add one event to the session journal and its readable log file.
+
+        `kind` is 'edit', 'undo' or 'redo'. Undos and redos are journalled too:
+        they create no new state, but they ARE things the user did, and a log
+        that omitted them would not match what happened.
+        """
+        entry = {"kind": kind, "meta": metadata, "at": datetime.now().isoformat(timespec="seconds")}
+        self.history_journal.append(entry)
+        append_journal(self.journal_path, kind, metadata)
+        return entry
+
+    def metadata_for_step(self, step):
+        """The record of what produced `step`, or None.
+
+        Reads through to the state file when it is not cached, so states written
+        by an earlier run of the app (session recovery, an imported history) can
+        still say what made them.
+        """
+        if step is None or step <= 0:
+            return None
+        if step in self._state_metadata:
+            return self._state_metadata[step]
+        metadata = read_metadata(self._get_state_filename(step))
+        if metadata:
+            self._state_metadata[step] = metadata
+        return metadata
+
+    def _reload_metadata_from_files(self):
+        """Rebuild the cache from the state files on disk (after an import)."""
+        self._state_metadata = {}
+        for step in range(1, self.max_step + 1):
+            metadata = read_metadata(self._get_state_filename(step))
+            if metadata:
+                self._state_metadata[step] = metadata
+
+    def current_state_description(self):
+        """What produced the state currently on the canvas."""
+        return describe(self.metadata_for_step(self.current_step))
+
+    def get_history_entries(self):
+        """Every saved step, oldest first, with what produced it.
+
+        Returns dicts of {step, metadata, description, is_current} — the data a
+        history view needs to list what was done rather than just how many
+        anonymous steps exist.
+        """
+        entries = []
+        for step in range(1, self.max_step + 1):
+            metadata = self.metadata_for_step(step)
+            entries.append({
+                "step": step,
+                "metadata": metadata,
+                "description": describe(metadata),
+                "is_current": step == self.current_step,
+            })
+        return entries
+
+    def get_session_journal(self):
+        """The session's running record: every edit, undo and redo in order."""
+        return [{
+            "kind": e["kind"],
+            "at": e["at"],
+            "description": describe(e["meta"]),
+            "metadata": e["meta"],
+        } for e in self.history_journal]
+
     def undo(self):
+        """Undo one step, recording it in the session journal."""
+        # The state being left carries the action that created it — which is
+        # exactly what this undo reverses.
+        reversed_action = self.metadata_for_step(self.current_step)
+        before = self.current_step
+        result = self._undo_impl()
+        if self.current_step != before:
+            self._journal('undo', reversed_action)
+            self._update_button_states()
+        return result
+
+    def redo(self):
+        """Redo one step, recording it in the session journal."""
+        before = self.current_step
+        result = self._redo_impl()
+        if self.current_step != before:
+            # Re-entering a state replays the action that made it.
+            self._journal('redo', self.metadata_for_step(self.current_step))
+            self._update_button_states()
+        return result
+
+    def _undo_impl(self):
         """Load the previous state if available."""
         if self.current_step > 0:
             # Store the current strands for comparison
@@ -1546,7 +1673,7 @@ class UndoRedoManager(QObject):
                     # If no visual difference found, skip this state and continue undoing
                     if not has_visual_difference:
                         # Recursively call undo to get to the next state
-                        return self.undo()
+                        return self._undo_impl()
                 
             self.undo_performed.emit()
             
@@ -1594,7 +1721,7 @@ class UndoRedoManager(QObject):
         else:
             pass
 
-    def redo(self):
+    def _redo_impl(self):
         """Load the next state if available."""
         if self.current_step < self.max_step:
             # Store the current strands for comparison
@@ -2008,7 +2135,7 @@ class UndoRedoManager(QObject):
                     # If no visual difference found, skip this state and continue redoing
                     if not has_visual_difference:
                         # Recursively call redo to get to the next state
-                        return self.redo() # Return the result of the recursive call
+                        return self._redo_impl() # Return the result of the recursive call
                     else:
                         pass
                         
@@ -2584,7 +2711,9 @@ class UndoRedoManager(QObject):
             
             _ = translations[language_code]
             if can_undo:
-                self.undo_button.set_custom_tooltip(_['undo_tooltip'])
+                # Say WHAT would be undone, not just that undo is available.
+                self.undo_button.set_custom_tooltip(
+                    self._with_action(_['undo_tooltip'], self.metadata_for_step(self.current_step)))
             else:
                 # Add "currently unavailable" to the tooltip when disabled
                 unavailable_text = _['currently_unavailable'] if 'currently_unavailable' in _ else 'Currently unavailable'
@@ -2607,7 +2736,8 @@ class UndoRedoManager(QObject):
             
             _ = translations[language_code]
             if can_redo:
-                self.redo_button.set_custom_tooltip(_['redo_tooltip'])
+                self.redo_button.set_custom_tooltip(
+                    self._with_action(_['redo_tooltip'], self.metadata_for_step(self.current_step + 1)))
             else:
                 # Add "currently unavailable" to the tooltip when disabled
                 unavailable_text = _['currently_unavailable'] if 'currently_unavailable' in _ else 'Currently unavailable'
@@ -2730,6 +2860,16 @@ class UndoRedoManager(QObject):
         
         return self.undo_button, self.redo_button
     
+    @staticmethod
+    def _with_action(tooltip, metadata):
+        """Append the recorded action to a button tooltip.
+
+        An unrecorded state (an older state file, or a save from a build without
+        this feature) leaves the tooltip exactly as the app has always shown it.
+        """
+        label = short_label(metadata)
+        return f"{tooltip}\n{label}" if label else tooltip
+
     def update_button_tooltips(self, language_code='en'):
         """Update button tooltips with the current language"""
         if self.undo_button and self.redo_button:
@@ -2738,13 +2878,15 @@ class UndoRedoManager(QObject):
             
             # Check if buttons are enabled and set appropriate tooltip
             if self.undo_button.isEnabled():
-                self.undo_button.set_custom_tooltip(_['undo_tooltip'])
+                self.undo_button.set_custom_tooltip(
+                    self._with_action(_['undo_tooltip'], self.metadata_for_step(self.current_step)))
             else:
                 unavailable_text = _['currently_unavailable'] if 'currently_unavailable' in _ else 'Currently unavailable'
                 self.undo_button.set_custom_tooltip(_['undo_tooltip'] + f'\n({unavailable_text})')
                 
             if self.redo_button.isEnabled():
-                self.redo_button.set_custom_tooltip(_['redo_tooltip'])
+                self.redo_button.set_custom_tooltip(
+                    self._with_action(_['redo_tooltip'], self.metadata_for_step(self.current_step + 1)))
             else:
                 unavailable_text = _['currently_unavailable'] if 'currently_unavailable' in _ else 'Currently unavailable'
                 self.redo_button.set_custom_tooltip(_['redo_tooltip'] + f'\n({unavailable_text})')
@@ -2761,10 +2903,14 @@ class UndoRedoManager(QObject):
 
         self.current_step = 0
         self.max_step = 0
+        # The step records described files that no longer exist. The session
+        # journal is NOT cleared: it records what was done, not what can still
+        # be undone.
+        self._state_metadata = {}
 
         if save_current:
             # Save current state as the initial state (step 1)
-            self.save_state() # This increments current_step to 1 and saves
+            self.save_state(action='system.new', source='system')  # increments current_step to 1 and saves
         else:
             # If not saving current, just reset steps and update buttons
             self._update_button_states()
@@ -2906,7 +3052,8 @@ class UndoRedoManager(QObject):
             # This guarantees that any changes since the last automatic save
             # are included in the exported history.
             if not self._would_be_identical_save():
-                self.save_state()
+                self.save_state(action='system.setting', source='system',
+                                detail='captured before exporting the history')
 
             history_payload = {
                 "type": "OpenStrandStudioHistory",
@@ -3000,6 +3147,10 @@ class UndoRedoManager(QObject):
             if not load_success:
                 return False
 
+            # The recreated files carry their own provenance — read it back so
+            # an imported history still says what produced each step.
+            self._reload_metadata_from_files()
+
             # Update UI buttons
             self._update_button_states()
             return True
@@ -3084,6 +3235,9 @@ def connect_to_move_mode(canvas, undo_redo_manager):
             # IMPORTANT: Capture control point flags BEFORE they get reset
             was_moving_control_point = getattr(canvas.move_mode, 'is_moving_control_point', False)
             was_moving_bias_control = getattr(canvas.move_mode, 'is_moving_bias_control', False)
+            # Capture WHICH strand was dragged before the release resets the mode,
+            # so the saved state can name it.
+            moved_strand = getattr(canvas.move_mode, 'affected_strand', None)
             
             # Call the original function first to finalize the move and reset flags
             original_mouse_release(event)
@@ -3097,7 +3251,10 @@ def connect_to_move_mode(canvas, undo_redo_manager):
                 # If a control point was being moved (including bias controls), reset the last save time to force a new state
                 if was_moving_control_point or was_moving_bias_control:
                     undo_redo_manager._last_save_time = 0
-                undo_redo_manager.save_state()
+                undo_redo_manager.save_state(
+                    action='move.strand', source='mode',
+                    targets=[getattr(moved_strand, 'layer_name', None)] if moved_strand else None,
+                    detail='control point' if (was_moving_control_point or was_moving_bias_control) else None)
             else:
                 pass
         
@@ -3163,7 +3320,7 @@ def connect_to_attach_mode(canvas, undo_redo_manager):
                     
                     # Temporarily lift the suppression to allow exactly one save
                     setattr(undo_redo_manager, '_skip_save', False)
-                    undo_redo_manager.save_state()
+                    undo_redo_manager.save_state(action='attach.child', source='mode')
                     
                     # Mark as completed to prevent duplicate saves
                     setattr(undo_redo_manager, '_attach_save_completed', True)
@@ -3211,7 +3368,7 @@ def connect_to_mask_mode(canvas, undo_redo_manager):
                 
                 # Temporarily lift the suppression to allow exactly one save
                 setattr(undo_redo_manager, '_skip_save', False)
-                undo_redo_manager.save_state()
+                undo_redo_manager.save_state(action='mask.create', source='mode')
                 
                 # Mark as completed to prevent duplicate saves
                 setattr(undo_redo_manager, '_mask_save_completed', True)
@@ -3255,7 +3412,9 @@ def connect_to_group_operations(canvas, undo_redo_manager):
                 # For operations that have completion functions, we'll save state at completion
                 # For other operations, save state immediately
                 if operation not in ["move", "rotate", "edit_angles"]:
-                    undo_redo_manager.save_state()
+                    undo_redo_manager.save_state(
+                        action='group.' + operation if 'group.' + operation in ACTIONS else 'group.edit',
+                        source='panel', targets=[group_name], detail=operation)
                 
             # Connect the signal
             group_manager.group_operation.connect(on_group_operation)
@@ -3267,7 +3426,8 @@ def connect_to_group_operations(canvas, undo_redo_manager):
         original_canvas_finish_move = canvas.finish_group_move
         def enhanced_canvas_finish_move(*args, **kwargs):
             result = original_canvas_finish_move(*args, **kwargs)
-            undo_redo_manager.save_state()
+            undo_redo_manager.save_state(action='group.move', source='dialog',
+                                         targets=[a for a in args if isinstance(a, str)])
             return result
         canvas.finish_group_move = enhanced_canvas_finish_move
         
@@ -3332,7 +3492,9 @@ def connect_strand_creation(canvas, undo_redo_manager):
                 
             # Save state for regular main strands only
             # Use a small delay to ensure all strand properties and connections are established
-            QTimer.singleShot(50, lambda: undo_redo_manager.save_state())
+            QTimer.singleShot(50, lambda: undo_redo_manager.save_state(
+                action='attach.new', source='mode',
+                targets=[getattr(strand, 'layer_name', None)]))
 
         try:
             canvas.strand_created.disconnect() # Clear previous connections if any
@@ -3434,10 +3596,12 @@ def connect_group_panel_directly(group_panel, undo_redo_manager):
             
             # Force a save anyway to ensure group creation is recorded as a separate step
             # This ensures that strand creation and group creation are treated as separate operations
-            undo_redo_manager.save_state()
+            undo_redo_manager.save_state(action='group.create', source='panel',
+                                         targets=[a for a in args if isinstance(a, str)])
         else:
             # Normal save if no recent save
-            undo_redo_manager.save_state()
+            undo_redo_manager.save_state(action='group.create', source='panel',
+                                         targets=[a for a in args if isinstance(a, str)])
             # Record the timestamp
             undo_redo_manager._last_save_time = time.time()
             # Mark that we're in a saving state
@@ -3452,7 +3616,8 @@ def connect_group_panel_directly(group_panel, undo_redo_manager):
     original_delete_group = group_panel.delete_group
     def enhanced_delete_group(*args, **kwargs):
         result = original_delete_group(*args, **kwargs)
-        undo_redo_manager.save_state()
+        undo_redo_manager.save_state(action='group.delete', source='panel',
+                                     targets=[a for a in args if isinstance(a, str)])
         return result
     group_panel.delete_group = enhanced_delete_group
     
@@ -3460,7 +3625,8 @@ def connect_group_panel_directly(group_panel, undo_redo_manager):
     original_finish_group_move = group_panel.finish_group_move
     def enhanced_finish_group_move(*args, **kwargs):
         result = original_finish_group_move(*args, **kwargs)
-        undo_redo_manager.save_state()
+        undo_redo_manager.save_state(action='group.move', source='dialog',
+                                     targets=[a for a in args if isinstance(a, str)])
         return result
     group_panel.finish_group_move = enhanced_finish_group_move
     
@@ -3488,7 +3654,9 @@ def connect_group_panel_directly(group_panel, undo_redo_manager):
         # For operations that have completion functions, we'll save state at completion
         # For other operations, save state immediately
         if operation not in ["move", "rotate", "edit_angles"]:
-            undo_redo_manager.save_state()
+            undo_redo_manager.save_state(
+                action='group.' + operation if 'group.' + operation in ACTIONS else 'group.edit',
+                source='panel', targets=[group_name], detail=operation)
     
     group_panel.group_operation.connect(on_group_operation)
     

--- a/src/undo_redo_metadata.py
+++ b/src/undo_redo_metadata.py
@@ -156,18 +156,20 @@ def layer_names(canvas, indices):
 
 
 def set_member_names(canvas, set_number):
-    """Every layer in a set, by name.
+    """Every layer a change to `set_number` reaches, by name.
 
-    A whole-set edit (colour, stroke, width) walks canvas.strands applying the
-    change to each layer whose name starts with "<set>_", so that is exactly
-    what the history entry has to name — recording only the clicked layer
-    understates what the step did.
+    A whole-set edit (colour, stroke, width) repaints each layer whose name
+    begins with the set — and a mask, named "<over>_<n>_<under>_<m>", is also
+    repainted when the set is its SECOND component: the layer panel redraws its
+    border in that colour (on_color_changed). Both belong in the record;
+    naming only the clicked layer understates what the step did.
     """
-    prefix = "{}_".format(str(set_number).split("_")[0])
+    set_id = str(set_number).split("_")[0]
     names = []
     for strand in getattr(canvas, "strands", None) or []:
         name = getattr(strand, "layer_name", None)
-        if name and name.startswith(prefix):
+        parts = name.split("_") if name else []
+        if parts and (parts[0] == set_id or (len(parts) == 4 and parts[2] == set_id)):
             names.append(name)
     return names
 

--- a/src/undo_redo_metadata.py
+++ b/src/undo_redo_metadata.py
@@ -155,6 +155,23 @@ def layer_names(canvas, indices):
     return names
 
 
+def set_member_names(canvas, set_number):
+    """Every layer in a set, by name.
+
+    A whole-set edit (colour, stroke, width) walks canvas.strands applying the
+    change to each layer whose name starts with "<set>_", so that is exactly
+    what the history entry has to name — recording only the clicked layer
+    understates what the step did.
+    """
+    prefix = "{}_".format(str(set_number).split("_")[0])
+    names = []
+    for strand in getattr(canvas, "strands", None) or []:
+        name = getattr(strand, "layer_name", None)
+        if name and name.startswith(prefix):
+            names.append(name)
+    return names
+
+
 def build_metadata(action=None, source=None, targets=None, detail=None,
                    canvas=None, origin=None):
     """Build the record stored with a state.
@@ -266,21 +283,26 @@ def read_metadata(filename):
         return None
 
 
-def journal_line(kind, meta):
-    """One human-readable line of the session journal."""
-    stamp = (meta or {}).get("at") or datetime.now().isoformat(timespec="seconds")
+def journal_line(kind, meta, at=None):
+    """One human-readable line of the session journal.
+
+    `at` is when the EVENT happened. An undo replays a record made earlier, so
+    falling back to the state's own timestamp would log the undo at the moment
+    the state was first created and leave the log out of order.
+    """
+    stamp = at or datetime.now().isoformat(timespec="seconds")
     prefix = {"undo": "UNDO ", "redo": "REDO "}.get(kind, "")
     return "{}  {}{}".format(stamp, prefix, describe(meta))
 
 
-def append_journal(path, kind, meta):
+def append_journal(path, kind, meta, at=None):
     """Append one event to the session's readable history log.
 
     Best-effort: losing a log line must never break an undo.
     """
     try:
         with open(path, "a", encoding="utf-8") as f:
-            f.write(journal_line(kind, meta) + "\n")
+            f.write(journal_line(kind, meta, at) + "\n")
         return True
     except Exception:
         return False

--- a/src/undo_redo_metadata.py
+++ b/src/undo_redo_metadata.py
@@ -1,0 +1,264 @@
+"""Provenance metadata for undo/redo states.
+
+The undo/redo stack stores snapshots of the canvas: each temp_states/*.json file
+is what the drawing looked like at a step, and nothing more. That makes every
+step anonymous — you can walk back through twenty of them without ever learning
+WHAT produced each one.
+
+This module adds the missing half. Every saved state also records the action
+that created it: the mode that was active (attach / move / rotate / mask /
+angle adjust), or the panel, dialog or menu entry responsible when no mode is,
+plus the layers or groups it touched and when it happened. The record is written
+into the state file itself, so it travels with the state through undo, redo,
+export_history/import_history and a session recovered from disk.
+
+Deliberately free of PyQt imports: it is plain data + JSON, so it can be tested
+without a display.
+"""
+
+import json
+import os
+from datetime import datetime
+
+# Metadata is stored under this key inside a state file. load_strands ignores
+# top-level keys it does not know, so an older build reads these files fine and
+# a state file written by an older build simply has no record to report.
+METADATA_KEY = "undo_metadata"
+
+# Where an action came from. 'mode' is a canvas tool; the rest are the non-mode
+# surfaces that also change the document.
+SOURCES = ("mode", "panel", "dialog", "menu", "shortcut", "system")
+
+# Action catalogue: id -> human-readable description. Ids are stable and are
+# what gets persisted; the text is only for display, so rewording is safe.
+ACTIONS = {
+    # Canvas modes
+    "attach.new": "Drew a new strand",
+    "attach.child": "Attached a strand",
+    "move.strand": "Moved a point",
+    "rotate.strand": "Rotated a strand",
+    "angle.adjust": "Adjusted angle/length",
+    "mask.create": "Created a mask",
+    "mask.edit": "Edited a mask",
+
+    # Layer panel / layer buttons
+    "layer.add": "Added a strand",
+    "layer.delete": "Deleted a layer",
+    "layer.delete_all": "Cleared the canvas",
+    "layer.reorder": "Reordered layers",
+    "layer.lock": "Locked/unlocked a layer",
+    "layer.clear_locks": "Cleared all locks",
+    "layer.lock_mode": "Toggled lock mode",
+    "layer.select": "Changed the selection",
+
+    # Strand properties (layer-button context menu)
+    "strand.color": "Changed strand colour",
+    "strand.circle_stroke": "Changed circle stroke",
+    "strand.end_circle_stroke": "Changed end-circle stroke",
+    "strand.hidden": "Toggled layer visibility",
+    "strand.shadow_only": "Toggled shadow-only",
+    "strand.hide_shadow": "Toggled shadow hiding",
+    "strand.line_visible": "Toggled line visibility",
+    "strand.extension": "Toggled an extension line",
+    "strand.circle_visible": "Toggled an end circle",
+    "strand.arrow": "Toggled an arrow",
+    "strand.arrow_style": "Changed arrow style",
+    "strand.reset_mask": "Reset a mask",
+    "strand.close_knot": "Closed a knot",
+    "strand.paste": "Pasted strand data",
+    "strand.width": "Changed strand width",
+    "strand.shadow": "Edited strand shadow",
+
+    # Groups
+    "group.create": "Created a group",
+    "group.delete": "Deleted a group",
+    "group.rename": "Renamed a group",
+    "group.move": "Moved a group",
+    "group.rotate": "Rotated a group",
+    "group.angle": "Edited group angles",
+    "group.shadow": "Edited group shadow",
+    "group.edit": "Edited a group",
+
+    # System / bookkeeping
+    "system.load": "Loaded a document",
+    "system.new": "New document",
+    "system.setting": "Changed a setting",
+    "system.unknown": "Change",
+}
+
+# canvas.current_mode is a mode OBJECT, so the readable name comes from its
+# class. set_mode also stashes the string it was called with, which is preferred
+# when present because it distinguishes states the object cannot (new_strand).
+MODE_CLASS_NAMES = {
+    "AttachMode": "attach",
+    "MoveMode": "move",
+    "RotateMode": "rotate",
+    "MaskMode": "mask",
+    "AngleAdjustMode": "angle_adjust",
+    "SelectMode": "select",
+    "ViewMode": "view",
+}
+
+
+def infer_mode(canvas):
+    """The name of the mode active on `canvas`, or None."""
+    if canvas is None:
+        return None
+    name = getattr(canvas, "current_mode_name", None)
+    if isinstance(name, str) and name:
+        return name
+    mode = getattr(canvas, "current_mode", None)
+    if mode is None:
+        return None
+    if isinstance(mode, str):        # set_mode("control_points") stores a string
+        return mode
+    return MODE_CLASS_NAMES.get(type(mode).__name__, type(mode).__name__)
+
+
+def _clean_targets(targets):
+    """Normalize whatever a call site passed into a list of names."""
+    if targets is None:
+        return []
+    if isinstance(targets, str):
+        return [targets]
+    out = []
+    for t in targets:
+        if t is None:
+            continue
+        out.append(t if isinstance(t, str) else getattr(t, "layer_name", str(t)))
+    return out
+
+
+def layer_names(canvas, indices):
+    """Layer names for the given canvas.strands indices.
+
+    Call sites hold indices, not names; a name is what a log reader recognises.
+    Indices that no longer exist are skipped, so this is safe to call after the
+    strand list has changed.
+    """
+    strands = getattr(canvas, "strands", None) or []
+    names = []
+    for i in indices or []:
+        try:
+            name = getattr(strands[i], "layer_name", None)
+        except (IndexError, TypeError, KeyError):
+            continue
+        if name:
+            names.append(name)
+    return names
+
+
+def build_metadata(action=None, source=None, targets=None, detail=None,
+                   canvas=None, origin=None):
+    """Build the record stored with a state.
+
+    `action` is an id from ACTIONS (an unknown id still works — it is rendered
+    by prettifying it). `source` defaults to 'mode' when a mode is active and
+    'system' otherwise, so a save nobody annotated still says which tool the
+    user was holding. `origin` is the call site that asked for the save, which
+    keeps even an unannotated state traceable.
+    """
+    mode = infer_mode(canvas)
+    if not action:
+        action = "system.unknown"
+    if not source:
+        source = "mode" if mode else "system"
+    return {
+        "action": action,
+        "source": source,
+        "mode": mode,
+        "targets": _clean_targets(targets),
+        "detail": detail,
+        "origin": origin,
+        "at": datetime.now().isoformat(timespec="seconds"),
+    }
+
+
+def _prettify(action):
+    """Render an id nobody catalogued: 'foo.bar_baz' -> 'Foo bar baz'."""
+    words = action.replace(".", " ").replace("_", " ").strip()
+    return words[:1].upper() + words[1:]
+
+
+def describe(meta):
+    """One line describing what produced a state, e.g.
+    'Moved a point - 1_2  ·  move mode'."""
+    if not meta:
+        return "Unrecorded change"
+    parts = [ACTIONS.get(meta.get("action", ""), _prettify(meta.get("action", "")))]
+    what = list(meta.get("targets") or [])
+    if meta.get("detail"):
+        what.append(str(meta["detail"]))
+    if what:
+        parts.append(", ".join(what))
+    mode = meta.get("mode")
+    source = meta.get("source") or "system"
+    if source == "mode":
+        where = "{} mode".format(mode) if mode else "canvas"
+    else:
+        where = source
+    return "{}  ·  {}".format(" - ".join(parts), where)
+
+
+def short_label(meta):
+    """Compact form for a button tooltip: no source suffix."""
+    if not meta:
+        return ""
+    head = ACTIONS.get(meta.get("action", ""), _prettify(meta.get("action", "")))
+    targets = meta.get("targets") or []
+    return "{} ({})".format(head, ", ".join(targets)) if targets else head
+
+
+def write_metadata(filename, meta):
+    """Store `meta` inside an already-written state file.
+
+    Injected after save_strands rather than through it so the save format stays
+    the single source of truth for the drawing itself. A failure here must never
+    cost the state: the snapshot is already on disk and stays valid without it.
+    """
+    if not meta or not filename or not os.path.exists(filename):
+        return False
+    try:
+        with open(filename, "r", encoding="utf-8") as f:
+            data = json.load(f)
+        if not isinstance(data, dict):
+            return False
+        data[METADATA_KEY] = meta
+        with open(filename, "w", encoding="utf-8") as f:
+            json.dump(data, f, indent=2)
+        return True
+    except Exception:
+        return False
+
+
+def read_metadata(filename):
+    """The record stored in a state file, or None (older files carry none)."""
+    if not filename or not os.path.exists(filename):
+        return None
+    try:
+        with open(filename, "r", encoding="utf-8") as f:
+            data = json.load(f)
+        meta = data.get(METADATA_KEY) if isinstance(data, dict) else None
+        return meta if isinstance(meta, dict) else None
+    except Exception:
+        return None
+
+
+def journal_line(kind, meta):
+    """One human-readable line of the session journal."""
+    stamp = (meta or {}).get("at") or datetime.now().isoformat(timespec="seconds")
+    prefix = {"undo": "UNDO ", "redo": "REDO "}.get(kind, "")
+    return "{}  {}{}".format(stamp, prefix, describe(meta))
+
+
+def append_journal(path, kind, meta):
+    """Append one event to the session's readable history log.
+
+    Best-effort: losing a log line must never break an undo.
+    """
+    try:
+        with open(path, "a", encoding="utf-8") as f:
+            f.write(journal_line(kind, meta) + "\n")
+        return True
+    except Exception:
+        return False

--- a/src/undo_redo_metadata.py
+++ b/src/undo_redo_metadata.py
@@ -18,6 +18,7 @@ without a display.
 
 import json
 import os
+import tempfile
 from datetime import datetime
 
 # Metadata is stored under this key inside a state file. load_strands ignores
@@ -101,18 +102,24 @@ MODE_CLASS_NAMES = {
 
 
 def infer_mode(canvas):
-    """The name of the mode active on `canvas`, or None."""
+    """The name of the mode active on `canvas`, or None.
+
+    The mode OBJECT is read first because it cannot go stale: parts of the
+    canvas swap current_mode directly (select_strand drops back to attach mode
+    without going through set_mode), and trusting the remembered name there
+    would credit the state to whatever tool was held before. The name is the
+    fallback for the two cases an object cannot express — set_mode("new_strand")
+    leaves current_mode None, and "control_points" is stored as a bare string.
+    """
     if canvas is None:
         return None
-    name = getattr(canvas, "current_mode_name", None)
-    if isinstance(name, str) and name:
-        return name
     mode = getattr(canvas, "current_mode", None)
-    if mode is None:
-        return None
-    if isinstance(mode, str):        # set_mode("control_points") stores a string
+    if isinstance(mode, str) and mode:   # set_mode("control_points")
         return mode
-    return MODE_CLASS_NAMES.get(type(mode).__name__, type(mode).__name__)
+    if mode is not None:
+        return MODE_CLASS_NAMES.get(type(mode).__name__, type(mode).__name__)
+    name = getattr(canvas, "current_mode_name", None)
+    return name if isinstance(name, str) and name else None
 
 
 def _clean_targets(targets):
@@ -214,21 +221,36 @@ def write_metadata(filename, meta):
 
     Injected after save_strands rather than through it so the save format stays
     the single source of truth for the drawing itself. A failure here must never
-    cost the state: the snapshot is already on disk and stays valid without it.
+    cost the state, so the rewrite goes to a temporary file in the same
+    directory and is moved over the original only once it is complete: opening
+    the snapshot itself for writing would truncate it, and a dump that then
+    failed (a full disk, an I/O error) would destroy the undo step this is only
+    supposed to annotate.
     """
     if not meta or not filename or not os.path.exists(filename):
         return False
+    tmp_path = None
     try:
         with open(filename, "r", encoding="utf-8") as f:
             data = json.load(f)
         if not isinstance(data, dict):
             return False
         data[METADATA_KEY] = meta
-        with open(filename, "w", encoding="utf-8") as f:
+        directory = os.path.dirname(os.path.abspath(filename))
+        handle, tmp_path = tempfile.mkstemp(prefix=".undo_meta_", suffix=".json", dir=directory)
+        with os.fdopen(handle, "w", encoding="utf-8") as f:
             json.dump(data, f, indent=2)
+        os.replace(tmp_path, filename)   # atomic: the state file is never half-written
+        tmp_path = None
         return True
     except Exception:
         return False
+    finally:
+        if tmp_path and os.path.exists(tmp_path):
+            try:
+                os.remove(tmp_path)
+            except OSError:
+                pass
 
 
 def read_metadata(filename):

--- a/tests/copy_paste/test_strand_data_mixin.py
+++ b/tests/copy_paste/test_strand_data_mixin.py
@@ -34,9 +34,13 @@ class _StubUndoManager:
     def __init__(self):
         self.saves = 0
         self._last_save_time = 99
+        self.last_save_kwargs = {}
 
-    def save_state(self):
+    # save_state now also takes the provenance of the state being saved
+    # (undo_redo_metadata.py): what action produced it, and on what.
+    def save_state(self, allow_empty=False, **kwargs):
         self.saves += 1
+        self.last_save_kwargs = kwargs
 
 
 class _StubCanvas:

--- a/tests/copy_paste/test_strand_data_mixin.py
+++ b/tests/copy_paste/test_strand_data_mixin.py
@@ -103,6 +103,21 @@ def test_chip_paste_on_unticked_layer_hits_that_layer_only():
 
     panel.multi_selected_layers = {1}
     assert panel.paste_strand_data_via_chip(2, "start") == 1  # unticked -> alone
+    # The chip is a layer-button control, not the copy/paste menu: the history
+    # has to name the surface the paste actually came from.
+    assert panel.canvas.undo_redo_manager.last_save_kwargs['source'] == 'panel'
+
+
+def test_a_menu_paste_is_recorded_as_a_menu_paste():
+    panel = make_panel()
+    panel.copy_strand_data(0)
+    panel.multi_selected_layers = {1, 2}
+
+    assert panel.paste_copied_strand_data("start") == 2
+    kwargs = panel.canvas.undo_redo_manager.last_save_kwargs
+    assert kwargs['source'] == 'menu'
+    assert kwargs['action'] == 'strand.paste'
+    assert 'start' in kwargs['detail']
 
 
 def test_batch_paste_is_one_undo_step_and_keeps_clipboard():

--- a/tests/test_layer_color_scopes.py
+++ b/tests/test_layer_color_scopes.py
@@ -33,9 +33,13 @@ class FakeUndoRedoManager:
     def __init__(self):
         self._last_save_time = 1
         self.save_count = 0
+        self.last_save_kwargs = {}
 
-    def save_state(self):
+    # save_state now also takes the provenance of the state being saved
+    # (undo_redo_metadata.py): what action produced it, and on what.
+    def save_state(self, allow_empty=False, **kwargs):
         self.save_count += 1
+        self.last_save_kwargs = kwargs
 
 
 class FakeCanvas:
@@ -118,6 +122,9 @@ def test_set_wide_stroke_changes_only_matching_set(monkeypatch):
     assert color_tuple(strands[1].stroke_color) == (10, 20, 30, 200)
     assert color_tuple(strands[2].stroke_color) == (0, 0, 0, 255)
     assert panel.canvas.undo_redo_manager.save_count == 1
+    # The saved state records which menu entry produced it.
+    assert panel.canvas.undo_redo_manager.last_save_kwargs['action'] == 'strand.color'
+    assert 'whole set' in panel.canvas.undo_redo_manager.last_save_kwargs['detail']
 
 
 def test_layer_only_stroke_changes_only_clicked_strand(monkeypatch):

--- a/tests/test_undo_redo_metadata.py
+++ b/tests/test_undo_redo_metadata.py
@@ -327,14 +327,18 @@ def test_adopting_another_session_rebuilds_the_records_from_its_files(tmp_path):
     assert manager.metadata_for_step(1)["action"] == "mask.create"
 
 
-def test_a_whole_set_edit_names_every_layer_in_the_set():
+def test_a_whole_set_edit_names_every_layer_the_change_reaches():
     canvas = FakeCanvas([FakeStrand("1_1"), FakeStrand("1_2"), FakeStrand("2_1"),
                          FakeStrand("1_3_2_1")])
-    # Masks built on the set carry its prefix and are repainted with it.
+    # A mask carries the set of its OVER component first...
     assert meta.set_member_names(canvas, 1) == ["1_1", "1_2", "1_3_2_1"]
     assert meta.set_member_names(canvas, "1") == ["1_1", "1_2", "1_3_2_1"]
-    assert meta.set_member_names(canvas, 2) == ["2_1"]
+    # ...and the panel repaints its border when the UNDER component's set
+    # changes, so that mask belongs to set 2's record as well.
+    assert meta.set_member_names(canvas, 2) == ["2_1", "1_3_2_1"]
     assert meta.set_member_names(canvas, 9) == []
+    # A set number is matched whole: set 1 is not set 12.
+    assert meta.set_member_names(FakeCanvas([FakeStrand("12_1")]), 1) == []
 
 
 def test_a_journalled_undo_is_stamped_when_it_happened(tmp_path):

--- a/tests/test_undo_redo_metadata.py
+++ b/tests/test_undo_redo_metadata.py
@@ -306,3 +306,38 @@ def test_adopting_another_session_rebuilds_the_records_from_its_files(tmp_path):
     # Back to the first session: the cache must not answer with the other one's.
     manager._reload_metadata_from_files()
     assert manager.metadata_for_step(1)["action"] == "mask.create"
+
+
+def test_a_whole_set_edit_names_every_layer_in_the_set():
+    canvas = FakeCanvas([FakeStrand("1_1"), FakeStrand("1_2"), FakeStrand("2_1"),
+                         FakeStrand("1_3_2_1")])
+    # Masks built on the set carry its prefix and are repainted with it.
+    assert meta.set_member_names(canvas, 1) == ["1_1", "1_2", "1_3_2_1"]
+    assert meta.set_member_names(canvas, "1") == ["1_1", "1_2", "1_3_2_1"]
+    assert meta.set_member_names(canvas, 2) == ["2_1"]
+    assert meta.set_member_names(canvas, 9) == []
+
+
+def test_a_journalled_undo_is_stamped_when_it_happened(tmp_path):
+    """An undo replays a record made earlier; the log is a log of events."""
+    made_earlier = meta.build_metadata("attach.new", targets=["1_1"])
+    made_earlier["at"] = "2020-01-01T00:00:00"
+
+    line = meta.journal_line("undo", made_earlier, at="2026-08-31T18:30:00")
+    assert line.startswith("2026-08-31T18:30:00  UNDO")
+    assert "2020-01-01" not in line
+
+    # With no event time it still writes a line, stamped now rather than never.
+    assert meta.journal_line("edit", made_earlier).startswith("20")
+
+
+def test_the_manager_logs_each_event_at_its_own_time(tmp_path):
+    manager, _ = make_manager(tmp_path)
+    manager.save_state(allow_empty=True, action="attach.new", targets=["1_1"])
+    manager._undo_impl = lambda: setattr(manager, "current_step", 0) or True
+    manager.undo()
+
+    lines = Path(manager.journal_path).read_text(encoding="utf-8").strip().split("\n")
+    stamps = [line.split("  ")[0] for line in lines]
+    assert stamps == sorted(stamps)          # the log reads in the order it happened
+    assert lines[-1].split("  ")[1].startswith("UNDO")

--- a/tests/test_undo_redo_metadata.py
+++ b/tests/test_undo_redo_metadata.py
@@ -1,0 +1,237 @@
+"""Every undo/redo state records what produced it.
+
+The stack used to store snapshots and nothing else, so a step could not say
+which mode, panel, dialog or menu entry created it. These tests cover the
+record itself (undo_redo_metadata.py), the fact that it is written into the
+state file — so it survives a restart, an export/import and session recovery —
+and that the manager keeps a journal of what was done, undos included.
+"""
+
+import json
+import os
+import sys
+from pathlib import Path
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+SRC_DIR = Path(__file__).resolve().parents[1] / "src"
+if str(SRC_DIR) not in sys.path:
+    sys.path.insert(0, str(SRC_DIR))
+
+from PyQt5.QtWidgets import QApplication
+
+import undo_redo_metadata as meta
+from undo_redo_manager import UndoRedoManager
+
+APP = QApplication.instance() or QApplication([])
+
+
+class FakeMode:
+    pass
+
+
+class MoveMode(FakeMode):
+    pass
+
+
+class FakeStrand:
+    def __init__(self, layer_name):
+        self.layer_name = layer_name
+
+
+class FakeLayerPanel:
+    def __init__(self):
+        self.locked_layers = set()
+        self.lock_mode = False
+        self.language_code = "en"
+
+
+class FakeCanvas:
+    """The little of a canvas that saving a state actually touches."""
+
+    def __init__(self, strands=None):
+        self.strands = strands or []
+        self.groups = {}
+        self.strand_colors = {}
+        self.selected_strand = None
+        self.shadow_enabled = True
+        self.show_control_points = False
+        self.layer_panel = FakeLayerPanel()
+        self.current_mode = MoveMode()
+        self.current_mode_name = "move"
+
+
+def make_manager(tmp_path):
+    canvas = FakeCanvas()
+    manager = UndoRedoManager(canvas, canvas.layer_panel, str(tmp_path))
+    return manager, canvas
+
+
+# ----------------------------------------------------------------- the record
+
+def test_the_active_mode_is_recorded_even_when_the_caller_says_nothing():
+    canvas = FakeCanvas()
+    record = meta.build_metadata(canvas=canvas, origin="layer_panel.py:some_handler")
+    assert record["mode"] == "move"
+    assert record["source"] == "mode"
+    assert record["origin"] == "layer_panel.py:some_handler"
+
+
+def test_the_mode_falls_back_to_the_mode_object_class():
+    canvas = FakeCanvas()
+    del canvas.current_mode_name
+    assert meta.infer_mode(canvas) == "move"
+
+
+def test_a_described_action_names_what_it_touched_and_where_it_came_from():
+    record = meta.build_metadata("move.strand", source="mode", targets=["1_2"], detail="start")
+    record["mode"] = "move"
+    assert meta.describe(record) == "Moved a point - 1_2, start  ·  move mode"
+    assert meta.short_label(record) == "Moved a point (1_2)"
+
+
+def test_an_uncatalogued_action_still_reads_as_words():
+    record = meta.build_metadata("made.up_thing", source="panel")
+    assert meta.describe(record) == "Made up thing  ·  panel"
+
+
+def test_a_state_with_no_record_says_so_rather_than_rendering_blank():
+    assert meta.describe(None) == "Unrecorded change"
+    assert meta.short_label(None) == ""
+
+
+def test_targets_accept_names_strands_or_a_bare_string():
+    record = meta.build_metadata("layer.delete", targets=[FakeStrand("2_1"), "3_1", None])
+    assert record["targets"] == ["2_1", "3_1"]
+    assert meta.build_metadata("layer.delete", targets="1_1")["targets"] == ["1_1"]
+
+
+def test_layer_names_resolves_indices_and_skips_ones_that_are_gone():
+    canvas = FakeCanvas([FakeStrand("1_1"), FakeStrand("1_2")])
+    assert meta.layer_names(canvas, [0, 1, 7]) == ["1_1", "1_2"]
+
+
+# ------------------------------------------------------- it lives in the file
+
+def test_the_record_round_trips_through_the_state_file(tmp_path):
+    path = tmp_path / "state.json"
+    path.write_text(json.dumps({"strands": [], "groups": {}}), encoding="utf-8")
+    record = meta.build_metadata("mask.create", source="mode", targets=["1_1", "2_1"])
+
+    assert meta.write_metadata(str(path), record) is True
+    assert meta.read_metadata(str(path)) == record
+    # The drawing itself is untouched by the injection.
+    assert json.loads(path.read_text(encoding="utf-8"))["strands"] == []
+
+
+def test_a_state_file_without_a_record_reads_back_as_none(tmp_path):
+    path = tmp_path / "old_state.json"
+    path.write_text(json.dumps({"strands": []}), encoding="utf-8")
+    assert meta.read_metadata(str(path)) is None
+    assert meta.read_metadata(str(tmp_path / "missing.json")) is None
+
+
+# ------------------------------------------------------------ via the manager
+
+def test_saving_a_state_writes_its_provenance_into_the_state_file(tmp_path):
+    manager, _ = make_manager(tmp_path)
+    manager.save_state(allow_empty=True, action="layer.delete", source="panel",
+                       targets=["1_1"], detail="deleted")
+
+    assert manager.current_step == 1
+    stored = meta.read_metadata(manager._get_state_filename(1))
+    assert stored["action"] == "layer.delete"
+    assert stored["source"] == "panel"
+    assert stored["targets"] == ["1_1"]
+    assert stored["mode"] == "move"          # the tool that was held, recorded either way
+    assert stored["origin"].endswith("test_saving_a_state_writes_its_provenance_into_the_state_file")
+
+
+def test_an_unannotated_save_still_records_the_mode_and_the_call_site(tmp_path):
+    manager, _ = make_manager(tmp_path)
+    manager.save_state(allow_empty=True)
+    stored = manager.metadata_for_step(1)
+    assert stored["action"] == "system.unknown"
+    assert stored["mode"] == "move"
+    assert "test_undo_redo_metadata.py" in stored["origin"]
+
+
+def test_the_record_is_read_back_from_disk_when_it_is_not_cached(tmp_path):
+    manager, _ = make_manager(tmp_path)
+    manager.save_state(allow_empty=True, action="attach.new", targets=["1_1"])
+    manager._state_metadata = {}          # a session recovered from disk starts empty
+    assert manager.metadata_for_step(1)["action"] == "attach.new"
+
+
+def test_the_history_lists_every_step_with_what_produced_it(tmp_path):
+    manager, canvas = make_manager(tmp_path)
+    manager.save_state(allow_empty=True, action="attach.new", targets=["1_1"])
+    canvas.strands.append(FakeStrand("1_1"))          # so the next save is not identical
+    manager.save_state(allow_empty=True, action="strand.hidden", source="menu",
+                       targets=["1_1"], detail="hidden")
+
+    entries = manager.get_history_entries()
+    assert [e["step"] for e in entries] == [1, 2]
+    assert entries[0]["description"].startswith("Drew a new strand - 1_1")
+    assert entries[1]["description"].startswith("Toggled layer visibility - 1_1, hidden")
+    assert entries[1]["is_current"] is True
+    assert manager.current_state_description().startswith("Toggled layer visibility")
+
+
+def test_dropping_the_future_drops_its_records_too(tmp_path):
+    manager, canvas = make_manager(tmp_path)
+    manager.save_state(allow_empty=True, action="attach.new", targets=["1_1"])
+    canvas.strands.append(FakeStrand("1_1"))
+    manager.save_state(allow_empty=True, action="strand.hidden", targets=["1_1"])
+
+    manager.current_step = 1                          # as an undo leaves it
+    manager._clear_future_states()
+    assert manager.max_step == 1
+    assert 2 not in manager._state_metadata
+
+
+def test_the_journal_records_edits_and_the_undos_and_redos_themselves(tmp_path):
+    manager, canvas = make_manager(tmp_path)
+    manager.save_state(allow_empty=True, action="attach.new", targets=["1_1"])
+    canvas.strands.append(FakeStrand("1_1"))
+    manager.save_state(allow_empty=True, action="strand.hidden", targets=["1_1"])
+
+    # Stand in for the real load, which needs a live canvas: what is under test
+    # here is that undo()/redo() journal the action they moved across.
+    manager._undo_impl = lambda: setattr(manager, "current_step", manager.current_step - 1) or True
+    manager._redo_impl = lambda: setattr(manager, "current_step", manager.current_step + 1) or True
+
+    manager.undo()
+    manager.redo()
+
+    journal = manager.get_session_journal()
+    assert [e["kind"] for e in journal] == ["edit", "edit", "undo", "redo"]
+    # An undo reverses the action that made the state it left...
+    assert journal[2]["metadata"]["action"] == "strand.hidden"
+    # ...and a redo replays the action of the state it re-enters.
+    assert journal[3]["metadata"]["action"] == "strand.hidden"
+    assert "UNDO" in meta.journal_line("undo", journal[2]["metadata"])
+
+
+def test_an_undo_that_moved_nowhere_journals_nothing(tmp_path):
+    manager, _ = make_manager(tmp_path)
+    manager.save_state(allow_empty=True, action="attach.new", targets=["1_1"])
+    before = len(manager.history_journal)
+    manager._undo_impl = lambda: False          # e.g. nothing to undo
+    manager.undo()
+    assert len(manager.history_journal) == before
+
+
+def test_the_journal_is_mirrored_to_a_readable_log_next_to_the_states(tmp_path):
+    manager, _ = make_manager(tmp_path)
+    manager.save_state(allow_empty=True, action="mask.create", source="mode",
+                       targets=["1_1", "2_1"])
+    assert os.path.exists(manager.journal_path)
+    line = Path(manager.journal_path).read_text(encoding="utf-8").strip()
+    assert "Created a mask - 1_1, 2_1" in line
+
+
+def test_the_button_tooltip_names_the_action_and_survives_an_unrecorded_state():
+    record = meta.build_metadata("layer.delete", source="panel", targets=["2_1"])
+    assert UndoRedoManager._with_action("Undo", record) == "Undo\nDeleted a layer (2_1)"
+    assert UndoRedoManager._with_action("Undo", None) == "Undo"

--- a/tests/test_undo_redo_metadata.py
+++ b/tests/test_undo_redo_metadata.py
@@ -290,6 +290,25 @@ def test_the_readable_log_follows_the_session_being_worked_on(tmp_path):
     assert "20200101000000_history.log" in manager.journal_path
 
 
+def test_adopting_a_session_leaves_none_of_the_old_one_in_the_journal(tmp_path):
+    """The journal is "this session's activity" — after a switch it must be its."""
+    manager, _ = make_manager(tmp_path)
+    manager.save_state(allow_empty=True, action="attach.new", targets=["1_1"])
+    assert [e["kind"] for e in manager.history_journal] == ["edit"]
+
+    manager.session_id = "20200101000000"
+    manager._adopt_session("session 20200101000000 at step 3")
+
+    kinds = [e["kind"] for e in manager.history_journal]
+    assert kinds == ["load"]                      # nothing carried over
+    entry = manager.get_session_journal()[0]
+    assert entry["metadata"]["action"] == "system.load"
+    assert "20200101000000" in entry["description"]
+    # ...and the line went to the adopted session's log, not the one we left.
+    assert "20200101000000_history.log" in manager.journal_path
+    assert "Loaded a document" in Path(manager.journal_path).read_text(encoding="utf-8")
+
+
 def test_adopting_another_session_rebuilds_the_records_from_its_files(tmp_path):
     manager, canvas = make_manager(tmp_path)
     manager.save_state(allow_empty=True, action="attach.new", targets=["1_1"])

--- a/tests/test_undo_redo_metadata.py
+++ b/tests/test_undo_redo_metadata.py
@@ -34,6 +34,10 @@ class MoveMode(FakeMode):
     pass
 
 
+class AttachMode(FakeMode):
+    pass
+
+
 class FakeStrand:
     def __init__(self, layer_name):
         self.layer_name = layer_name
@@ -77,10 +81,31 @@ def test_the_active_mode_is_recorded_even_when_the_caller_says_nothing():
     assert record["origin"] == "layer_panel.py:some_handler"
 
 
-def test_the_mode_falls_back_to_the_mode_object_class():
+def test_the_mode_comes_from_the_mode_object_class():
     canvas = FakeCanvas()
     del canvas.current_mode_name
     assert meta.infer_mode(canvas) == "move"
+
+
+def test_the_live_mode_object_beats_a_remembered_name_that_went_stale():
+    # select_strand swaps current_mode straight to attach mode without going
+    # through set_mode, so the remembered name lags behind the real tool.
+    canvas = FakeCanvas()
+    canvas.current_mode = AttachMode()
+    canvas.current_mode_name = "rotate"          # stale
+    assert meta.infer_mode(canvas) == "attach"
+
+
+def test_the_remembered_name_covers_what_no_mode_object_can_express():
+    canvas = FakeCanvas()
+    canvas.current_mode = None                   # set_mode("new_strand")
+    canvas.current_mode_name = "new_strand"
+    assert meta.infer_mode(canvas) == "new_strand"
+    canvas.current_mode = "control_points"       # set_mode stores a bare string
+    assert meta.infer_mode(canvas) == "control_points"
+    canvas.current_mode = None
+    canvas.current_mode_name = None
+    assert meta.infer_mode(canvas) is None
 
 
 def test_a_described_action_names_what_it_touched_and_where_it_came_from():
@@ -235,3 +260,49 @@ def test_the_button_tooltip_names_the_action_and_survives_an_unrecorded_state():
     record = meta.build_metadata("layer.delete", source="panel", targets=["2_1"])
     assert UndoRedoManager._with_action("Undo", record) == "Undo\nDeleted a layer (2_1)"
     assert UndoRedoManager._with_action("Undo", None) == "Undo"
+
+
+def test_a_failed_metadata_rewrite_leaves_the_snapshot_intact(tmp_path, monkeypatch):
+    """The record is an annotation; losing it must never cost the undo step."""
+    path = tmp_path / "state.json"
+    original = json.dumps({"strands": [{"layer_name": "1_1"}], "groups": {}})
+    path.write_text(original, encoding="utf-8")
+
+    def explode(*args, **kwargs):
+        raise OSError("no space left on device")
+
+    monkeypatch.setattr(meta.json, "dump", explode)
+    assert meta.write_metadata(str(path), meta.build_metadata("attach.new")) is False
+    # The drawing is still there, byte for byte, and no debris was left behind.
+    assert path.read_text(encoding="utf-8") == original
+    assert [p.name for p in tmp_path.iterdir()] == ["state.json"]
+
+
+def test_the_readable_log_follows_the_session_being_worked_on(tmp_path):
+    manager, _ = make_manager(tmp_path)
+    first = manager.journal_path
+    assert manager.session_id in first
+
+    # load_specific_state adopts another session's id mid-run; the log has to
+    # follow it rather than keep appending to the session we left.
+    manager.session_id = "20200101000000"
+    assert manager.journal_path != first
+    assert "20200101000000_history.log" in manager.journal_path
+
+
+def test_adopting_another_session_rebuilds_the_records_from_its_files(tmp_path):
+    manager, canvas = make_manager(tmp_path)
+    manager.save_state(allow_empty=True, action="attach.new", targets=["1_1"])
+    assert manager.metadata_for_step(1)["action"] == "attach.new"
+
+    # A second session writes its own step 1 with a different action.
+    other = "20200101000000"
+    manager.session_id = other
+    canvas.strands.append(FakeStrand("2_1"))
+    manager.current_step = 0
+    manager.max_step = 0
+    manager.save_state(allow_empty=True, action="mask.create", targets=["2_1"])
+
+    # Back to the first session: the cache must not answer with the other one's.
+    manager._reload_metadata_from_files()
+    assert manager.metadata_for_step(1)["action"] == "mask.create"


### PR DESCRIPTION
## What

The undo/redo stack stored snapshots and nothing else — each `temp_states/*.json` was what the drawing looked like at a step, so a step could never say which mode, panel, dialog or menu entry created it.

Every saved state now carries that record: the active mode, the source (mode / panel / dialog / menu / system), the layers or groups it touched, a timestamp, and the call site that asked for the save. The undo stack doubles as a log of what was actually done.

## How

- **`src/undo_redo_metadata.py`** (new) — the record, the action catalogue, mode inference, the label builders, and the read/write of the record inside a state file. Deliberately free of PyQt imports so it is testable without a display.
- **`src/undo_redo_manager.py`** — `save_state(action=…, source=…, targets=…, detail=…)`. The record is written **into the state file** (`undo_metadata`) so it survives a restart, `export_history`/`import_history` and session recovery. `undo()` / `redo()` are now thin wrappers over the existing implementations that journal the action they moved across — undos and redos create no new state, but they are things the user did. New `get_history_entries()`, `get_session_journal()`, `metadata_for_step()`, `current_state_description()`.
- **Call sites annotated** across the layer panel, layer-button context menu, the modes (move / rotate / angle adjust / attach / mask), the group panel and every editing dialog. A `save_state()` that says nothing still records the active mode and the calling function, so no state is anonymous.
- **`src/strand_drawing_canvas.py`** — `set_mode` now remembers the mode *name*, since `current_mode` is an object (and `None` while drawing a new strand).
- **Surfaces** — undo/redo tooltips name the action they would reverse or replay; **Settings → History** gains a "Recorded actions" list (this session's activity, or a past session's saved steps, read from that session's files); a readable `<session id>_history.log` sits next to the state files.
- **`src/SAVE_LOAD_UNDO_REDO_GUIDE.md`** documents how to annotate a new edit.

Undo and redo restore exactly the states they did before — this is an audit trail layered on the existing snapshots.

## Verification

- **`tests/test_undo_redo_metadata.py`** (new, 18 tests): the record and its rendering, the state-file round trip, an old file without a record reading back as unrecorded, reading the record back from disk when nothing is cached, `get_history_entries`, dropping the future dropping its records, the journal (edits plus the undos/redos, and nothing journalled when an undo moved nowhere), the log file, and the tooltip.
- Existing suites pass (`tests/test_layer_color_scopes.py`, `tests/copy_paste`, `tests/selection` — 64 tests). The two stub undo managers there now accept the kwargs the real `save_state` takes, and assert the recorded action. (`tests/1.108` can't be collected in this environment — it needs QtMultimedia's pulse libs — unrelated to this change.)
- Driven headless against the real app (`QT_QPA_PLATFORM=offscreen`, MainWindow + the real modes wired up): drew a strand, toggled layer visibility, toggled lock mode, then undo and redo. The history read back as `Drew a new strand - 1_1 · attach mode`, `Toggled layer visibility - 1_1, hidden · menu`, `Toggled lock mode - off · panel`; the journal recorded the undo and redo; the tooltip read `Undo: / Undo last action / Toggled layer visibility (1_1)`; and the Settings → History page listed all of it, including a past session's steps when one is selected.

## Notes

Two new translation keys (`history_actions`, `no_actions_recorded`) in all seven languages.

---
_Generated by [Claude Code](https://claude.ai/code/session_01QdUHvwxpadZgn5mB8Rvxf9)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes are mostly metadata on top of existing undo snapshots, but they touch the central save/load path and many edit entry points; a wrong action id or session metadata cache could mislabel history without breaking restore.
> 
> **Overview**
> Undo/redo steps used to be anonymous snapshots. **Each save now records what caused it** — action id, source (`mode` / `panel` / `dialog` / `menu` / `system`), affected layer or group names, and optional detail — via new `undo_redo_metadata.py` and extended `save_state(action=…, source=…, targets=…, detail=…)`.
> 
> That **`undo_metadata` block is written into each state JSON** (atomic rewrite) so labels survive restart, history export/import, and session recovery; older files still load as “unrecorded.” **`UndoRedoManager`** journals edits plus undo/redo, exposes `get_history_entries()` / `get_session_journal()`, refreshes metadata on session adopt/import, and **undo/redo tooltips** name the step they would cross.
> 
> **Call sites across the app** (layer panel, context menus, modes, group dialogs, shadow editors, paste chip vs menu, etc.) pass catalogued action ids; unannotated saves still capture active mode and caller. **Settings → History** adds a **Recorded actions** list (live session journal or past session steps from disk) plus `<session>_history.log`. Docs and tests cover the pattern; seven locales get `history_actions` / `no_actions_recorded`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 227cded1c9fedc33e3836832bbc258a28cee5a34. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added detailed activity information to undo/redo history, including actions, sources, affected layers, and relevant details.
  * Added a localized History view in Settings with current- and past-session activity.
  * Improved undo/redo tooltips and journal entries with readable action descriptions.
  * Preserved history metadata across saved files, exports, imports, and session recovery.
  * Added support for viewing activity in multiple languages.

* **Documentation**
  * Added guidance for recording and using undo/redo action metadata.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->